### PR TITLE
don't register magic numbers multiple times

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,11 @@ pub mod pcx;
 
 /// Register all enabled extra formats with the image crate.
 pub fn register() {
-    image::hooks::register_decoding_hook(
+    let just_registered = image::hooks::register_decoding_hook(
         "pcx".into(),
         Box::new(|r| Ok(Box::new(pcx::PCXDecoder::new(r)?))),
     );
-    image::hooks::register_format_detection_hook("pcx".into(), &[0x0a, 0x0], Some(b"\xFF\xF8"));
+    if just_registered {
+        image::hooks::register_format_detection_hook("pcx".into(), &[0x0a, 0x0], Some(b"\xFF\xF8"));
+    }
 }


### PR DESCRIPTION
I don't know if there is deduplication for format detection hooks internally, but this will avoid some bloat if not.