### PR TITLE
Move forbid(unsafe_code) to the crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,8 @@
 //! // Now you can use the image crate as normal
 //! let img = image::open("path/to/image.pcx").unwrap();
 //! ```
-use image::Limits;
+
+#![forbid(unsafe_code)]
 
 #[cfg(feature = "pcx")]
 pub mod pcx;
@@ -44,7 +45,7 @@ pub fn register() {
             Box::new(|r| {
                 Ok(Box::new(ora::OpenRasterDecoder::with_limits(
                     r,
-                    Limits::no_limits(),
+                    image::Limits::no_limits(),
                 )?))
             }),
         );

--- a/src/ora.rs
+++ b/src/ora.rs
@@ -9,7 +9,7 @@
 //! # Related Links
 //! * <https://en.wikipedia.org/wiki/OpenRaster> - The OpenRaster format on Wikipedia
 //! * <https://www.openraster.org/> - OpenRaster specification
-#![forbid(unsafe_code)]
+
 use image::codecs::png::PngDecoder;
 use image::error::{DecodingError, ImageFormatHint, UnsupportedError};
 use image::metadata::Orientation;

--- a/src/xbm.rs
+++ b/src/xbm.rs
@@ -8,7 +8,6 @@
 //! # Related Links
 //! * <https://www.x.org/releases/X11R7.7/doc/libX11/libX11/libX11.html#Manipulating_Bitmaps> - The XBM format specification
 //! * <https://en.wikipedia.org/wiki/X_BitMap> - The XBM format on wikipedia
-#![forbid(unsafe_code)]
 
 use std::fmt;
 use std::io::{BufRead, Bytes};

--- a/src/xpm/mod.rs
+++ b/src/xpm/mod.rs
@@ -46,7 +46,6 @@
 //! * <https://gitlab.freedesktop.org/xorg/app/rgb/raw/master/rgb.txt> - X color names
 //! * <https://www.x.org/wiki/X11R4/#index10h4> - Introduction of modern X11 color name table
 //! * <https://web.archive.org/web/20070808230118/http://koala.ilog.fr/ftp/pub/xpm/> - more historical XPM material
-#![forbid(unsafe_code)]
 
 mod x11r6colors;
 


### PR DESCRIPTION
We can revisit if unsafe ends up being necessary somewhere. But it is nice to be able to rule out unsafe across all the formats with a single top-level directive