### PR TITLE
Support 32-bit floating-point colors in tests

### DIFF
--- a/tests/reference.rs
+++ b/tests/reference.rs
@@ -1,3 +1,4 @@
+use image::{ColorType, DynamicImage};
 use walkdir::WalkDir;
 
 #[test]
@@ -10,7 +11,7 @@ fn test_decoding() {
             continue;
         }
 
-        let img = image::open(entry.path()).unwrap();
+        let img = to_png_compatible_color_type(image::open(entry.path()).unwrap());
         let reference = image::open(entry.path().with_extension("png")).unwrap();
 
         assert_eq!(
@@ -19,5 +20,14 @@ fn test_decoding() {
             "Image {} does not match reference",
             entry.path().display()
         );
+    }
+}
+
+/// PNG doesn't support 32-bit float color types, so convert them to 16-bit.
+fn to_png_compatible_color_type(image: DynamicImage) -> DynamicImage {
+    match image.color() {
+        ColorType::Rgb32F => image.to_rgb16().into(),
+        ColorType::Rgba32F => image.to_rgba16().into(),
+        _ => image,
     }
 }


### PR DESCRIPTION
PNG only supports up to 16-bit colors, so this PR adds support for f32 test images by converting them to 16-bit before comparing them to the reference PNG.

This is necessary for #16.