### PR TITLE
Fixed clippy warnings

### DIFF
--- a/src/otb.rs
+++ b/src/otb.rs
@@ -116,7 +116,7 @@ impl<'a, W: Write> ImageEncoder for OtbEncoder<'a, W> {
                 };
             }
             if bit != 0 {
-                let _ = self.writer.write_all(&[current_byte])?;
+                self.writer.write_all(&[current_byte])?;
                 bit = 0;
                 current_byte = 0;
             }
@@ -452,7 +452,7 @@ mod test {
         ];
         let mut encoded_data = Vec::<u8>::with_capacity(expected_data.len());
         let encoder = crate::otb::OtbEncoder::new(&mut encoded_data).unwrap();
-        let _ = encoder
+        encoder
             .write_image(&img_data, 8, 8, image::ExtendedColorType::L8)
             .unwrap();
         encoded_data.iter().enumerate().for_each(|(i, byte)| {
@@ -490,7 +490,7 @@ mod test {
         ];
         let mut encoded_data = Vec::<u8>::with_capacity(expected_data.len());
         let encoder = crate::otb::OtbEncoder::new(&mut encoded_data).unwrap();
-        let _ = encoder
+        encoder
             .write_image(&img_data, 10, 10, image::ExtendedColorType::L8)
             .unwrap();
         encoded_data.iter().enumerate().for_each(|(i, byte)| {

--- a/src/pcx.rs
+++ b/src/pcx.rs
@@ -92,7 +92,7 @@ impl<R: BufRead + Seek> ImageDecoder for PCXDecoder<R> {
             // by taking the paletted image into a buffer, then converting it to
             // RGB8 after.
             Some(palette_length) => {
-                let mut pal_buf: Vec<u8> = iter::repeat(0).take(height * width).collect();
+                let mut pal_buf: Vec<u8> = iter::repeat_n(0, height * width).collect();
 
                 for i in 0..height {
                     let offset = i * width;
@@ -102,7 +102,7 @@ impl<R: BufRead + Seek> ImageDecoder for PCXDecoder<R> {
                 }
 
                 let mut palette: Vec<u8> =
-                    iter::repeat(0).take(3 * palette_length as usize).collect();
+                    std::iter::repeat_n(0, 3 * palette_length as usize).collect();
                 self.inner
                     .read_palette(&mut palette[..])
                     .map_err(convert_pcx_decode_error)?;

--- a/src/xpm/x11r6colors.rs
+++ b/src/xpm/x11r6colors.rs
@@ -48,7 +48,7 @@
 /// Table entries are (name, R, G, B) tuples.
 /// Names are lowercase.
 /// Some but not all multi-word names have an additional form with spaces between words.
-pub const COLORS: [(&str, u8, u8, u8); 752] = [
+pub const COLORS: &[(&str, u8, u8, u8)] = &[
     ("alice blue", 240, 248, 255),
     ("aliceblue", 240, 248, 255),
     ("antique white", 250, 235, 215),


### PR DESCRIPTION
I fixed all clippy warnings.

Should I also add a CI action to check to disallow all clippy warnings? Pro: no clippy warnings. Cons: new Rust releases adding warns will cause CI to fail.