### PR TITLE
Add CI check to ensure that features work independently

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,6 +57,15 @@ jobs:
     - name: Run rustfmt check
       run: cargo fmt -- --check
 
+  features:
+    # make sure that features compile individually
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-hack
+      - run: cargo hack check --each-feature --no-dev-deps
+
   cargo-deny:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds a CI to verify that all features compile on their own. This prevents decoders from accidentally sharing dependencies or code incorrectly.

If you do not think that such a CI check is necessary, feel free to reject this PR.