### PR TITLE
Improved documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ include = ["src", "tests/reference.rs"]
 [features]
 default = ["ora", "otb", "pcx", "sgi", "xbm", "xpm", "wbmp"]
 
-# Each feature below is the file extention for the file format decoder it
-# enables.
+# Each feature below is the file extension for the file format encoder/decoder
+# it enables.
 ora = ["image/png", "dep:zip", "dep:ouroboros"]
 otb = []
 sgi = []

--- a/README.md
+++ b/README.md
@@ -1,26 +1,47 @@
 # image-extras
 
-Decoding support for additional image formats beyond those provided by the
+Support for additional image formats beyond those provided by the
 [`image`](https://crates.io/crates/image) crate.
 
-## Supported formats
+## Usage
 
-| Extension | Specification or Format Description |
-| --------- | -------------------- |
-| ORA | [Specification](https://www.openraster.org) |
-| PCX | [Wikipedia](https://en.wikipedia.org/wiki/PCX#PCX_file_format) |
-| WBMP | [Specification](https://www.wapforum.org/what/technical/SPEC-WAESpec-19990524.pdf) |
-| OTB | [Specification](https://www.wapforum.org/what/technical/SPEC-WAESpec-19990524.pdf) |
-| SGI | [Specification](https://web.archive.org/web/20010413154909/https://reality.sgi.com/grafica/sgiimage.html) |
-| XBM | [Specification](https://www.x.org/releases/X11R7.7/doc/libX11/libX11/libX11.html#Manipulating_Bitmaps) |
-| XPM | [Specification](https://www.x.org/docs/XPM/xpm.pdf) |
+Call the `register` function at program startup:
+
+```rust
+fn main() {
+    image_extras::register();
+
+    // Now you can use the image crate as normal
+    let img = image::open("path/to/image.pcx").unwrap();
+}
+```
+
+By default, all supported formats are enabled. For finer control, enable
+individual formats via Cargo features:
+
+```toml
+[dependencies]
+image_extras = { version = "0.1", features = ["pcx"], default-features = false }
+```
+
+## Supported Formats
+
+| Feature | Format
+| ------- | ------
+| `ora`   | OpenRaster [\[spec\]](https://www.openraster.org/)
+| `otb`   | OTA Bitmap (Over The Air Bitmap) [\[spec\]](https://www.wapforum.org/what/technical/SPEC-WAESpec-19990524.pdf)
+| `pcx`   | PCX (ZSoft Paintbrush bitmap/PiCture eXchange) [\[desc\]](https://en.wikipedia.org/wiki/PCX#PCX_file_format)
+| `sgi`   | SGI (Silicon Graphics Image) [\[spec\]](https://web.archive.org/web/20010413154909/https://reality.sgi.com/grafica/sgiimage.html)
+| `wbmp`  | Wireless Bitmap [\[spec\]](https://www.wapforum.org/what/technical/SPEC-WAESpec-19990524.pdf)
+| `xbm`   | X BitMap [\[spec\]](https://www.x.org/releases/X11R7.7/doc/libX11/libX11/libX11.html#Manipulating_Bitmaps)
+| `xpm`   | X PixMap [\[spec\]](https://www.x.org/docs/XPM/xpm.pdf)
 
 By default, `image-extras` enables support for all included formats. This is
-convienient for prototyping, but for other uses you are encouraged to evaluate
+convenient for prototyping, but for other uses you are encouraged to evaluate
 the individual implementations and enable only the ones that meet your
 quality/robustness requirements.
 
-## New Formats
+### New Formats
 
 We welcome PRs to add support for additional image formats.
 
@@ -42,7 +63,6 @@ We welcome PRs to add support for additional image formats.
 | `image` crate version | Compatible `image-extras` versions |
 | --------------------- | ---------------------------------- |
 | 0.25.x                | 0.1.x                              |
-
 
 ## Fuzzing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,6 @@
 //! This crate provides additional formats for the image crate.
 //!
-//! The enabled formats are controlled via Cargo features:
-//! ```toml
-//! [dependencies]
-//! image_extras = { version = "0.1", features = ["pcx"] }
-//! ```
-//!
-//! And you must also call the `register` function at program startup:
+//! Call the [`register`] function at program startup:
 //!
 //!  ```rust,no_run
 //! image_extras::register();
@@ -14,6 +8,9 @@
 //! // Now you can use the image crate as normal
 //! let img = image::open("path/to/image.pcx").unwrap();
 //! ```
+//!
+//! By default, all supported formats are enabled. For finer control, enable
+//! individual formats via Cargo features.
 
 #![forbid(unsafe_code)]
 
@@ -44,6 +41,9 @@ use image::hooks::{register_decoding_hook, register_format_detection_hook};
 static REGISTER: std::sync::Once = std::sync::Once::new();
 
 /// Register all enabled extra formats with the image crate.
+///
+/// Calling this function more than once is allowed but has no additional
+/// effect.
 pub fn register() {
     REGISTER.call_once(|| {
         // OpenRaster images are ZIP files and have no simple signature to distinguish them

--- a/src/wbmp.rs
+++ b/src/wbmp.rs
@@ -1,4 +1,4 @@
-//! Encoding and Deciding of WBMP Images
+//! Encoding and Decoding of WBMP Images
 //!
 //! WBMP (Wireless BitMaP) Format is an image format used by the WAP protocol.
 //!


### PR DESCRIPTION
I improved the docs a little:

1. I copied the usage section into the README and shortened it in `lib.rs`. People on crates.io can now see how to use the crate.
2. Added mission `default-features = false`.
3. I changed the format table to document all features and format names.