### PR TITLE
Avoid trait bounds on structs when possible

### DIFF
--- a/src/otb.rs
+++ b/src/otb.rs
@@ -185,10 +185,7 @@ impl error::Error for DecoderError {
 }
 
 /// Decoder for Otb images.
-pub struct OtbDecoder<R>
-where
-    R: BufRead + Seek,
-{
+pub struct OtbDecoder<R> {
     reader: R,
     dimensions: (u32, u32),
 }

--- a/src/pcx.rs
+++ b/src/pcx.rs
@@ -5,7 +5,7 @@
 //! # Related Links
 //! * <https://en.wikipedia.org/wiki/PCX> - The PCX format on Wikipedia
 
-use std::io::{self, BufRead, Seek};
+use std::io::{self, BufRead, Read, Seek};
 use std::iter;
 
 use image::{ColorType, ExtendedColorType, ImageDecoder, ImageError, ImageResult};
@@ -13,7 +13,7 @@ use image::{ColorType, ExtendedColorType, ImageDecoder, ImageError, ImageResult}
 /// Decoder for PCX images.
 pub struct PCXDecoder<R>
 where
-    R: BufRead + Seek,
+    R: Read,
 {
     dimensions: (u32, u32),
     inner: pcx::Reader<R>,

--- a/src/sgi.rs
+++ b/src/sgi.rs
@@ -197,10 +197,7 @@ fn parse_header(
 }
 
 /// Decoder for SGI (.rgb) images.
-pub struct SgiDecoder<R>
-where
-    R: BufRead,
-{
+pub struct SgiDecoder<R> {
     info: SgiRgbHeaderInfo,
     reader: R,
 }

--- a/src/wbmp.rs
+++ b/src/wbmp.rs
@@ -68,10 +68,7 @@ impl<'a, W: Write> ImageEncoder for WbmpEncoder<'a, W> {
 }
 
 /// Decoder for Wbmp images.
-pub struct WbmpDecoder<R>
-where
-    R: BufRead + Seek,
-{
+pub struct WbmpDecoder<R> {
     dimensions: (u32, u32),
     inner: wbmp::Decoder<R>,
 }

--- a/src/xbm.rs
+++ b/src/xbm.rs
@@ -27,7 +27,7 @@ struct TextLocation {
 }
 
 /// A peekable reader which tracks location information
-struct TextReader<R: Iterator<Item = u8>> {
+struct TextReader<R> {
     inner: R,
 
     current: Option<u8>,
@@ -89,7 +89,7 @@ struct XbmHeaderData {
 ///
 /// To properly validate the image trailer, invoke `next_byte()` again after reading the last byte of content; if
 /// the trailer is valid it should return Ok(None).
-struct XbmStreamDecoder<R: Iterator<Item = u8>> {
+struct XbmStreamDecoder<R> {
     r: TextReader<R>,
     current_position: u64,
     // Note: technically this includes header metadata that isn't _needed_ when parsing
@@ -99,7 +99,7 @@ struct XbmStreamDecoder<R: Iterator<Item = u8>> {
 /// Helper struct to project BufRead down to Iterator<Item=u8>. Costs of this simple
 /// lifetime-free abstraction include that the struct requires space to store the
 /// error value, and that code using this must eventually check the error field.
-struct IoAdapter<R: BufRead> {
+struct IoAdapter<R> {
     reader: Bytes<R>,
     error: Option<std::io::Error>,
 }
@@ -126,7 +126,7 @@ where
 }
 
 /// XBM decoder (usable wrapper of XbmStreamDecoder that handles IO errors)
-pub struct XbmDecoder<R: BufRead> {
+pub struct XbmDecoder<R> {
     base: XbmStreamDecoder<IoAdapter<R>>,
 }
 

--- a/src/xpm/mod.rs
+++ b/src/xpm/mod.rs
@@ -73,7 +73,7 @@ struct TextLocation {
 }
 
 /// A peekable reader which tracks location information
-struct TextReader<R: Iterator<Item = u8>> {
+struct TextReader<R> {
     inner: R,
 
     current: Option<u8>,
@@ -127,7 +127,7 @@ where
 /// Helper struct to project BufRead down to Iterator<Item=u8>. Costs of this simple
 /// lifetime-free abstraction include that the struct requires space to store the
 /// error value, and that code using this must eventually check the error field.
-struct IoAdapter<R: BufRead> {
+struct IoAdapter<R> {
     reader: Bytes<R>,
     error: Option<std::io::Error>,
 }
@@ -154,7 +154,7 @@ where
 }
 
 /// XPM decoder
-pub struct XpmDecoder<R: BufRead> {
+pub struct XpmDecoder<R> {
     r: TextReader<IoAdapter<R>>,
     info: XpmHeaderInfo,
 }


### PR DESCRIPTION
Having trait bounds on the structs' implementations suffices.

For context, see https://github.com/image-rs/image-extras/pull/16#issuecomment-3575174756.

Note: `PCXDecoder` still requires `Read` for `pcx::Reader`; I haven't figured out how to remove the trait bounds for `OpenRasterDecoder`, for which ZipFile requires `Read`.