### PR TITLE
Improve OTA Bitmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ image_extras = { version = "0.1", features = ["pcx"], default-features = false }
 | Feature | Format
 | ------- | ------
 | `ora`   | OpenRaster [\[spec\]](https://www.openraster.org/)
-| `otb`   | OTA Bitmap (Over The Air Bitmap) [\[spec\]](https://www.wapforum.org/what/technical/SPEC-WAESpec-19990524.pdf)
+| `otb`   | OTA Bitmap (Over The Air Bitmap) [\[desc\]](https://en.wikipedia.org/wiki/OTA_bitmap)
 | `pcx`   | PCX (ZSoft Paintbrush bitmap/PiCture eXchange) [\[desc\]](https://en.wikipedia.org/wiki/PCX#PCX_file_format)
 | `sgi`   | SGI (Silicon Graphics Image) [\[spec\]](https://web.archive.org/web/20010413154909/https://reality.sgi.com/grafica/sgiimage.html)
 | `wbmp`  | Wireless Bitmap [\[spec\]](https://www.wapforum.org/what/technical/SPEC-WAESpec-19990524.pdf)


### PR DESCRIPTION
Changes:

- Fixed link to spec.
- Removed lifetime parameter from `OtbEncoder` by taking the writer by value.
- `OtbEncoder::new` no longer returns a result, because it can never error.
- `OtbDecoder::read_image` now panics instead of returning an error if `buf` has the wrong length. This is the behavior defined by the `ImageDecoder` trait.
- `OtbDecoder::read_image` will now read exactly the right amount of bytes from disk. This fixes the unbound memory allocation and the bug that truncated images were partially decoded and returned `Ok(())`.
- `OtbDecoder::read_metadata` now reads the entire header at once instead of byte by byte.
- Simplified `DecoderError`