### PR TITLE
Add test for file variations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,5 @@ zip = { version = "5.1.1", default-features = false, features = ["deflate"], opt
 
 [dev-dependencies]
 image = { version = "0.25.8", default-features = false, features = ["png", "tiff"] }
+tempfile = "3.23.0"
 walkdir = "2.5.0"

--- a/tests/reference.rs
+++ b/tests/reference.rs
@@ -1,5 +1,20 @@
+use std::path::PathBuf;
+
 use image::ColorType;
+use tempfile::tempdir;
 use walkdir::WalkDir;
+
+fn iter_decoding_images() -> impl Iterator<Item = PathBuf> {
+    WalkDir::new("tests/images")
+        .into_iter()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| {
+            entry.file_type().is_file()
+                && entry.path().extension().unwrap() != "png"
+                && entry.path().extension().unwrap() != "tiff"
+        })
+        .map(|entry| entry.path().to_owned())
+}
 
 /// Test decoding of all test images in `tests/images/` against reference images
 /// (either PNG or TIFF).
@@ -23,20 +38,14 @@ fn test_decoding() {
     let bless = std::env::var("BLESS").is_ok();
     let mut errors = vec![];
 
-    for entry in WalkDir::new("tests/images") {
-        let entry = entry.unwrap();
-        if !entry.file_type().is_file()
-            || entry.path().extension().unwrap() == "png"
-            || entry.path().extension().unwrap() == "tiff"
-        {
-            continue;
-        }
+    for img_path in iter_decoding_images() {
+        let img_path = img_path.as_path();
 
         let mut add_error = |e: &str| {
-            errors.push(format!("{}: {}", entry.path().display(), e));
+            errors.push(format!("{}: {}", img_path.display(), e));
         };
 
-        let img = match image::open(entry.path()) {
+        let img = match image::open(img_path) {
             Ok(i) => i,
             Err(e) => {
                 add_error(&format!("Cannot decode image: {e}"));
@@ -48,7 +57,7 @@ fn test_decoding() {
             ColorType::Rgb32F | ColorType::Rgba32F => "tiff",
             _ => "png",
         };
-        let ref_path = &entry.path().with_extension(ref_format);
+        let ref_path = &img_path.with_extension(ref_format);
 
         let save_reference = || {
             if bless {
@@ -74,11 +83,58 @@ fn test_decoding() {
             img,
             reference,
             "Image {} does not match reference",
-            entry.path().display()
+            img_path.display()
         );
     }
 
     if !errors.is_empty() {
         panic!("Decoding errors:\n{}", errors.join("\n"));
     }
+}
+
+/// This test takes valid images from `tests/images/` and applies various
+/// modifications to them (truncation, extension with garbage data, byte mutations)
+/// and ensures that decoding them does not panic.
+#[test]
+fn test_decoding_variations() {
+    image_extras::register();
+
+    let tmp_dir = tempdir().unwrap();
+
+    for img_path in iter_decoding_images() {
+        let img_path = img_path.as_path();
+        let ext = img_path.extension().unwrap().to_string_lossy().to_string();
+
+        let bytes = std::fs::read(img_path).unwrap();
+
+        // test truncations
+        for i in (0..1000.min(bytes.len())).step_by(37) {
+            let shorter_path = tmp_dir.path().join(format!("truncation.{ext}"));
+            std::fs::write(&shorter_path, &bytes[..i]).unwrap();
+            _ = image::open(shorter_path); // just check it doesn't panic
+        }
+
+        // test extension
+        let mut longer = bytes.clone();
+        longer.extend_from_slice(b"I am garbage data at the end of the file!");
+        let longer_path = tmp_dir.path().join(format!("extension.{ext}"));
+        std::fs::write(&longer_path, &longer).unwrap();
+        _ = image::open(longer_path); // just check it doesn't panic
+
+        // test mutations
+        let mut mutations_buffer = bytes.clone().into_boxed_slice();
+        for i in 0..16.min(mutations_buffer.len()) {
+            let mask = 0b0101_0101;
+            mutations_buffer[i] ^= mask;
+
+            let shorter_path = tmp_dir.path().join(format!("mutations.{ext}"));
+            std::fs::write(&shorter_path, &bytes[..i]).unwrap();
+            _ = image::open(shorter_path); // just check it doesn't panic
+
+            // undo mutation
+            mutations_buffer[i] ^= mask;
+        }
+    }
+
+    tmp_dir.close().unwrap();
 }


### PR DESCRIPTION
I added a test that mutates the image files we already have and checks that decoders do not panic for them. Current mutations include:

1. Truncations like `image` tests for too.
2. An extension where is just appends garbage.
3. Header mutations where certain header bytes are changed.

This would have found a panic in OBT that was fixed by #28.

---

Unfortunately, this test is currently a lot slower than it has to be because `image` only supports using plugins when reading files. This forces the test to write the modified files to disk for every mutation that we want to test. Writing to disk makes the test a lot slower than it has to be, but it's not too bad. It only takes 2 sec on my machine. 

I made https://github.com/image-rs/image/pull/2662 to address this API oversight. But even if a solution gets added, we probably won't be able to use the solution right away due to version compatibility.