### PR TITLE
ORA: Avoid lifetime constraint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["dds", "icns", "ora", "otb", "pcx", "sgi", "xbm", "xpm", "wbmp"]
 # it enables.
 dds = ["dep:dds"]
 icns = ["dep:png", "dep:icns"]
-ora = ["image/png", "dep:zip"]
+ora = ["image/png", "dep:zip", "dep:ouroboros"]
 otb = []
 sgi = []
 pcx = ["dep:pcx"]
@@ -31,6 +31,7 @@ image = { version = "0.25.8", default-features = false }
 # Optional dependencies
 dds = { version = "0.2.0", optional = true }
 icns = { version = "0.4.0", default-features = false, optional = true }
+ouroboros = { version = "0.18.5", optional = true }
 pcx = { version = "0.2.4", optional = true }
 png = { version = "0.18.0", default-features = false, optional = true }
 wbmp = { version = "0.1.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["dds", "icns", "ora", "otb", "pcx", "sgi", "xbm", "xpm", "wbmp"]
 # it enables.
 dds = ["dep:dds"]
 icns = ["dep:png", "dep:icns"]
-ora = ["image/png", "dep:zip", "dep:ouroboros"]
+ora = ["image/png", "dep:zip"]
 otb = []
 sgi = []
 pcx = ["dep:pcx"]
@@ -31,7 +31,6 @@ image = { version = "0.25.8", default-features = false }
 # Optional dependencies
 dds = { version = "0.2.0", optional = true }
 icns = { version = "0.4.0", default-features = false, optional = true }
-ouroboros = { version = "0.18.5", optional = true }
 pcx = { version = "0.2.4", optional = true }
 png = { version = "0.18.0", default-features = false, optional = true }
 wbmp = { version = "0.1.2", optional = true }

--- a/src/ora.rs
+++ b/src/ora.rs
@@ -280,6 +280,16 @@ impl<R: Read + Seek> ImageDecoder for OpenRasterDecoder<R> {
         let decoder = PngDecoder::with_limits(BufReader::new(file), self.limits.clone())
             .map_err(set_ora_image_type)?;
 
+        // `ImageDecoder::read_image` will panic if the dimensions and color type
+        // don't match those from the initial header parsing.
+        // Check them here and return an error instead.
+        if decoder.dimensions() != self.dimensions || decoder.color_type() != self.color_type {
+            return Err(ImageError::Decoding(DecodingError::new(
+                openraster_format_hint(),
+                "Merged image dimensions and color type changed",
+            )));
+        }
+
         decoder.read_image(buf)
     }
 

--- a/src/ora.rs
+++ b/src/ora.rs
@@ -14,16 +14,16 @@ use image::codecs::png::PngDecoder;
 use image::error::{DecodingError, ImageFormatHint, UnsupportedError};
 use image::metadata::Orientation;
 use image::{ColorType, ExtendedColorType, ImageDecoder, ImageError, ImageResult, Limits};
-use ouroboros::self_referencing;
-use std::io::{self, BufReader, Read, Seek};
+use std::io::{Cursor, Read, Seek};
 use std::marker::PhantomData;
-use zip::read::{ZipArchive, ZipFile};
+use zip::read::ZipArchive;
 
-pub struct OpenRasterDecoder<'a, R>
+pub struct OpenRasterDecoder<R>
 where
-    R: Read + Seek + 'a,
+    R: Read + Seek,
 {
-    mergedimg_decoder: PngDecoder<BufReader<SeekableArchiveFile<'a, R>>>,
+    mergedimg_decoder: PngDecoder<Cursor<Vec<u8>>>,
+    _phantom: PhantomData<R>,
 }
 
 fn openraster_format_hint() -> ImageFormatHint {
@@ -51,100 +51,9 @@ fn set_ora_image_type(err: ImageError) -> ImageError {
     }
 }
 
-#[self_referencing]
-struct SeekableArchiveCore<'a, R: Read + Seek + 'a> {
-    archive: ZipArchive<R>,
-    #[covariant]
-    #[borrows(mut archive)]
-    file: ZipFile<'this, R>,
-    lifetime_helper: PhantomData<&'a R>,
-}
-
-/// The zip crate does not provide a seekable reader that works on compressed
-/// entries, while png::Decoder requires the Seek bound (but does not currently
-/// use it). This structure implements Seek by reopening and reading the zip
-/// archive entry whenever it seeks backwards.
-struct SeekableArchiveFile<'a, R: Read + Seek + 'a> {
-    core: Option<SeekableArchiveCore<'a, R>>,
-    file_index: usize,
-    position: u64,
-    file_size: u64,
-}
-
-impl<'a, R: Read + Seek + 'a> SeekableArchiveFile<'a, R> {
-    fn new(
-        archive: ZipArchive<R>,
-        file_index: usize,
-    ) -> Result<SeekableArchiveFile<'a, R>, io::Error> {
-        let core = SeekableArchiveCore::try_new(archive, |x| x.by_index(file_index), PhantomData)
-            .map_err(|x| io::Error::other(format!("failed to open: {:?}", x)))?;
-        let file_size = core.with_file(|file| file.size());
-        Ok(SeekableArchiveFile {
-            core: Some(core),
-            file_index,
-            position: 0,
-            file_size,
-        })
-    }
-}
-
-impl<R: Read + Seek> Read for SeekableArchiveFile<'_, R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let res = self
-            .core
-            .as_mut()
-            .unwrap()
-            .with_file_mut(|file| file.read(buf));
-        let nread = res?;
-        self.position
-            .checked_add(nread as u64)
-            .ok_or_else(|| io::Error::other("seek position overflow"))?;
-        Ok(nread)
-    }
-}
-
-impl<R: Read + Seek> Seek for SeekableArchiveFile<'_, R> {
-    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
-        let target_pos = match pos {
-            io::SeekFrom::Start(offset) => offset,
-            io::SeekFrom::End(offset) => self
-                .file_size
-                .checked_add_signed(offset)
-                .ok_or_else(|| io::Error::other("seek position over or underflow"))?,
-            io::SeekFrom::Current(offset) => self
-                .position
-                .checked_add_signed(offset)
-                .ok_or_else(|| io::Error::other("seek position over or underflow"))?,
-        };
-
-        if target_pos < self.position {
-            let core = self.core.take();
-            let archive = core.unwrap().into_heads().archive;
-
-            self.core = Some(
-                SeekableArchiveCore::try_new(archive, |x| x.by_index(self.file_index), PhantomData)
-                    .map_err(|x| io::Error::other(format!("failed to reopen: {:?}", x)))?,
-            );
-        }
-        while self.position < target_pos {
-            const TMP_LEN: usize = 1024;
-            let mut tmp = [0_u8; TMP_LEN];
-            let cur_pos = self.position;
-            let nr = self
-                .read(&mut tmp[..std::cmp::min(TMP_LEN as u64, target_pos - cur_pos) as usize])?;
-            if nr == 0 {
-                return Err(io::Error::other("unexpected eof when seeking"));
-            }
-            self.position += nr as u64;
-        }
-
-        Ok(0)
-    }
-}
-
-impl<'a, R> OpenRasterDecoder<'a, R>
+impl<R> OpenRasterDecoder<R>
 where
-    R: Read + Seek + 'a,
+    R: Read + Seek,
 {
     /// Create a new `OpenRasterDecoder` with the provided limits.
     ///
@@ -158,7 +67,7 @@ where
     /// forms an OpenRaster file), memory constraints on the ZIP file decoding
     /// process have not yet been implemented; input ZIP files with very many
     /// entries may require significant amounts of memory to read.
-    pub fn with_limits(r: R, limits: Limits) -> Result<OpenRasterDecoder<'a, R>, ImageError> {
+    pub fn with_limits(r: R, mut limits: Limits) -> Result<OpenRasterDecoder<R>, ImageError> {
         let mut archive = ZipArchive::new(r)
             .map_err(|e| ImageError::Decoding(DecodingError::new(openraster_format_hint(), e)))?;
 
@@ -190,6 +99,7 @@ where
 
         drop(mimetype_file);
 
+        /* Read the full PNG into a buffer. */
         let mergedimage_index = archive.index_for_name("mergedimage.png").ok_or_else(|| {
             ImageError::Decoding(DecodingError::new(
                 openraster_format_hint(),
@@ -197,17 +107,33 @@ where
             ))
         })?;
 
-        let file = SeekableArchiveFile::new(archive, mergedimage_index)?;
+        let mut mergedimage = archive
+            .by_index(mergedimage_index)
+            .map_err(|x| ImageError::Decoding(DecodingError::new(openraster_format_hint(), x)))?;
+        let size = mergedimage.size();
+        if size > isize::MAX as u64 {
+            return Err(ImageError::Limits(image::error::LimitError::from_kind(
+                image::error::LimitErrorKind::InsufficientMemory,
+            )));
+        }
+
+        limits.reserve(size)?;
+        let mut buf = Vec::new();
+        buf.try_reserve_exact(size as usize)?;
+
+        mergedimage.read_to_end(&mut buf)?;
+
         let decoder =
-            PngDecoder::with_limits(BufReader::new(file), limits).map_err(set_ora_image_type)?;
+            PngDecoder::with_limits(Cursor::new(buf), limits).map_err(set_ora_image_type)?;
 
         Ok(OpenRasterDecoder {
             mergedimg_decoder: decoder,
+            _phantom: PhantomData,
         })
     }
 }
 
-impl<'a, R: Read + Seek + 'a> ImageDecoder for OpenRasterDecoder<'a, R> {
+impl<R: Read + Seek> ImageDecoder for OpenRasterDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
         self.mergedimg_decoder.dimensions()
     }

--- a/src/ora.rs
+++ b/src/ora.rs
@@ -14,17 +14,10 @@ use image::codecs::png::PngDecoder;
 use image::error::{DecodingError, ImageFormatHint, UnsupportedError};
 use image::metadata::Orientation;
 use image::{ColorType, ExtendedColorType, ImageDecoder, ImageError, ImageResult, Limits};
-use std::io::{Cursor, Read, Seek};
+use ouroboros::self_referencing;
+use std::io::{self, BufReader, Read, Seek};
 use std::marker::PhantomData;
-use zip::read::ZipArchive;
-
-pub struct OpenRasterDecoder<R>
-where
-    R: Read + Seek,
-{
-    mergedimg_decoder: PngDecoder<Cursor<Vec<u8>>>,
-    _phantom: PhantomData<R>,
-}
+use zip::read::{ZipArchive, ZipFile};
 
 fn openraster_format_hint() -> ImageFormatHint {
     ImageFormatHint::Name("OpenRaster".into())
@@ -48,6 +41,97 @@ fn set_ora_image_type(err: ImageError) -> ImageError {
             UnsupportedError::from_format_and_kind(openraster_format_hint(), e.kind()),
         ),
         ImageError::IoError(e) => ImageError::IoError(e),
+    }
+}
+
+#[self_referencing]
+struct SeekableArchiveCore<'a, 'zip: 'a, R: Read + Seek + 'a> {
+    archive: &'zip mut ZipArchive<R>,
+    #[covariant]
+    #[borrows(mut archive)]
+    file: ZipFile<'this, R>,
+    lifetime_helper: PhantomData<&'a R>,
+}
+
+/// The zip crate does not provide a seekable reader that works on compressed
+/// entries, while png::Decoder requires the Seek bound (but does not currently
+/// use it). This structure implements Seek by reopening and reading the zip
+/// archive entry whenever it seeks backwards.
+struct SeekableArchiveFile<'a, 'zip, R: Read + Seek + 'a> {
+    core: Option<SeekableArchiveCore<'a, 'zip, R>>,
+    file_index: usize,
+    position: u64,
+    file_size: u64,
+}
+
+impl<'a, 'zip, R: Read + Seek + 'a> SeekableArchiveFile<'a, 'zip, R> {
+    fn new(
+        archive: &'zip mut ZipArchive<R>,
+        file_index: usize,
+    ) -> Result<SeekableArchiveFile<'a, 'zip, R>, io::Error> {
+        let core = SeekableArchiveCore::try_new(archive, |x| x.by_index(file_index), PhantomData)
+            .map_err(|x| io::Error::other(format!("failed to open: {:?}", x)))?;
+        let file_size = core.with_file(|file| file.size());
+        Ok(SeekableArchiveFile {
+            core: Some(core),
+            file_index,
+            position: 0,
+            file_size,
+        })
+    }
+}
+
+impl<R: Read + Seek> Read for SeekableArchiveFile<'_, '_, R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let res = self
+            .core
+            .as_mut()
+            .unwrap()
+            .with_file_mut(|file| file.read(buf));
+        let nread = res?;
+        self.position
+            .checked_add(nread as u64)
+            .ok_or_else(|| io::Error::other("seek position overflow"))?;
+        Ok(nread)
+    }
+}
+
+impl<R: Read + Seek> Seek for SeekableArchiveFile<'_, '_, R> {
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        let target_pos = match pos {
+            io::SeekFrom::Start(offset) => offset,
+            io::SeekFrom::End(offset) => self
+                .file_size
+                .checked_add_signed(offset)
+                .ok_or_else(|| io::Error::other("seek position over or underflow"))?,
+            io::SeekFrom::Current(offset) => self
+                .position
+                .checked_add_signed(offset)
+                .ok_or_else(|| io::Error::other("seek position over or underflow"))?,
+        };
+
+        if target_pos < self.position {
+            let core = self.core.take();
+            let archive = core.unwrap().into_heads().archive;
+
+            self.core = Some(
+                SeekableArchiveCore::try_new(archive, |x| x.by_index(self.file_index), PhantomData)
+                    .map_err(|x| io::Error::other(format!("failed to reopen: {:?}", x)))?,
+            );
+        }
+        while self.position < target_pos {
+            const TMP_LEN: usize = 1024;
+            let mut tmp = [0_u8; TMP_LEN];
+            let cur_pos = self.position;
+            let nr = self
+                .read(&mut tmp[..std::cmp::min(TMP_LEN as u64, target_pos - cur_pos) as usize])?;
+            if nr == 0 {
+                return Err(io::Error::other("unexpected eof when seeking"));
+            }
+            self.position += nr as u64;
+        }
+
+        Ok(0)
     }
 }
 
@@ -80,6 +164,23 @@ fn verify_archive(archive: &mut ZipArchive<impl Read + Seek>) -> ImageResult<()>
     Ok(())
 }
 
+pub struct OpenRasterDecoder<R>
+where
+    R: Read + Seek,
+{
+    dimensions: (u32, u32),
+    color_type: ColorType,
+    original_color_type: ExtendedColorType,
+    orientation: Orientation,
+    icc_profile: Option<Vec<u8>>,
+    exif_metadata: Option<Vec<u8>>,
+
+    limits: Limits,
+
+    archive: ZipArchive<R>,
+    mergedimage_index: usize,
+}
+
 impl<R> OpenRasterDecoder<R>
 where
     R: Read + Seek,
@@ -96,13 +197,12 @@ where
     /// forms an OpenRaster file), memory constraints on the ZIP file decoding
     /// process have not yet been implemented; input ZIP files with very many
     /// entries may require significant amounts of memory to read.
-    pub fn with_limits(r: R, mut limits: Limits) -> Result<OpenRasterDecoder<R>, ImageError> {
+    pub fn with_limits(r: R, limits: Limits) -> ImageResult<Self> {
         let mut archive = ZipArchive::new(r)
             .map_err(|e| ImageError::Decoding(DecodingError::new(openraster_format_hint(), e)))?;
 
         verify_archive(&mut archive)?;
 
-        // Read the full PNG into a buffer.
         let mergedimage_index = archive.index_for_name("mergedimage.png").ok_or_else(|| {
             ImageError::Decoding(DecodingError::new(
                 openraster_format_hint(),
@@ -110,64 +210,77 @@ where
             ))
         })?;
 
-        let mut mergedimage = archive
-            .by_index(mergedimage_index)
-            .map_err(|x| ImageError::Decoding(DecodingError::new(openraster_format_hint(), x)))?;
-        let size = mergedimage.size();
-        if size > isize::MAX as u64 {
-            return Err(ImageError::Limits(image::error::LimitError::from_kind(
-                image::error::LimitErrorKind::InsufficientMemory,
-            )));
-        }
+        let file = SeekableArchiveFile::new(&mut archive, mergedimage_index)?;
+        let mut decoder = PngDecoder::with_limits(BufReader::new(file), limits.clone())
+            .map_err(set_ora_image_type)?;
 
-        limits.reserve(size)?;
-        let mut buf = Vec::new();
-        buf.try_reserve_exact(size as usize)?;
+        let dimensions = decoder.dimensions();
+        let color_type = decoder.color_type();
+        let original_color_type = decoder.original_color_type();
+        let orientation = decoder.orientation().map_err(set_ora_image_type)?;
+        let icc_profile = decoder.icc_profile().map_err(set_ora_image_type)?;
+        let exif_metadata = decoder.exif_metadata().map_err(set_ora_image_type)?;
 
-        mergedimage.read_to_end(&mut buf)?;
+        // Drop the decoder now and re-create it later. This allows us to avoid
+        // a life time in the `OpenRasterDecoder` struct.
+        drop(decoder);
 
-        let decoder =
-            PngDecoder::with_limits(Cursor::new(buf), limits).map_err(set_ora_image_type)?;
+        Ok(Self {
+            dimensions,
+            color_type,
+            original_color_type,
+            orientation,
+            icc_profile,
+            exif_metadata,
 
-        Ok(OpenRasterDecoder {
-            mergedimg_decoder: decoder,
-            _phantom: PhantomData,
+            limits,
+
+            archive,
+            mergedimage_index,
         })
     }
 }
 
 impl<R: Read + Seek> ImageDecoder for OpenRasterDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
-        self.mergedimg_decoder.dimensions()
+        self.dimensions
     }
 
     fn color_type(&self) -> ColorType {
-        self.mergedimg_decoder.color_type()
+        self.color_type
     }
 
     fn original_color_type(&self) -> ExtendedColorType {
-        self.mergedimg_decoder.original_color_type()
+        self.original_color_type
     }
 
     fn set_limits(&mut self, limits: Limits) -> ImageResult<()> {
         // Warning: this does not account for any ZIP reading overhead
-        self.mergedimg_decoder.set_limits(limits)
+        self.limits = limits;
+        self.limits
+            .check_dimensions(self.dimensions.0, self.dimensions.1)
     }
 
     fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
-        self.mergedimg_decoder.icc_profile()
+        Ok(self.icc_profile.clone())
     }
 
     fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
-        self.mergedimg_decoder.exif_metadata()
+        Ok(self.exif_metadata.clone())
     }
 
     fn orientation(&mut self) -> ImageResult<Orientation> {
-        self.mergedimg_decoder.orientation()
+        Ok(self.orientation)
     }
 
-    fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
-        self.mergedimg_decoder.read_image(buf)
+    fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
+        // re-open mergedimage.png file and decode it with the provided limits
+        let file = SeekableArchiveFile::new(&mut self.archive, self.mergedimage_index)
+            .map_err(ImageError::IoError)?;
+        let decoder = PngDecoder::with_limits(BufReader::new(file), self.limits.clone())
+            .map_err(set_ora_image_type)?;
+
+        decoder.read_image(buf)
     }
 
     fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {


### PR DESCRIPTION
Fixes #39

### The problem

The cause of #39 is that `OpenRasterDecoder` has a constraint for the lifetime of `R`, which in turn messes with how lifetimes are inferred. Frankly, I don't understand what exact rules lead the borrow checker to reject this; I just know that `R: 'a` is the problem.

Why do we need `R: 'a` in the first place? Because the `zip` crate's [`ZipFile` has a reference](https://docs.rs/zip/latest/zip/read/struct.ZipFile.html) to its parent `ZipArchive`, which leads to a self-referential struct for us. The previous implementation handled this using `ouroboros`, which required `R: 'a`.

### Possible solutions

So there are basically two ways to get around this:
1. Implement the self-referential struct differently. This is *assuming* that the bound `R: 'a` is only an artifact of `ouroboros` and not actually required for soundness.
2. Avoid the self-referential struct.

### What I implemented

I opted for the second option, because it's a lot simpler. I just read `mergedimage.png` (which contains the image data) into a buffer. So instead of decoding the zip archive on the fly, the PNG is decoded when an `OpenRasterDecoder` is created, which avoids the need to store a `ZipFile` inside a struct.

This also has the additional advantage that `SeekableArchiveFile` becomes unnecessary. Of course, the main downside is memory usage. Frankly, I simply hope that PNG's compression ratio is good enough so that keeping the entire PNG in memory is a reasonable fraction of the memory of the decoded image. 

**Note:** This also means that `OpenRasterDecoder` doesn't depend on the reader at all, since all the reading is done in `with_limits`. This isn't necessarily an issue by itself, but also means that `struct OpenRasterDecoder<R>` doesn't need the type parameter `R` anymore. I **kept** the type parameter, in case we change the implementation of `OpenRasterDecoder` in the future. So if we find a better approach later, it won't be a breaking change.