### PR TITLE
Draft: Implement new ImageDecoder interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ xpm = []
 
 
 [dependencies]
-image = { version = "0.25.8", default-features = false }
+image = { git = "https://github.com/image-rs/image", rev = "cf89a940096d7bfdf64899d99cbb4010acb38d2c", default-features = false }
 
 # Optional dependencies
 dds = { version = "0.2.0", optional = true }
@@ -38,5 +38,6 @@ wbmp = { version = "0.1.2", optional = true }
 zip = { version = "5.1.1", default-features = false, features = ["deflate"], optional = true }
 
 [dev-dependencies]
-image = { version = "0.25.8", default-features = false, features = ["png", "tiff"] }
+image = { git = "https://github.com/image-rs/image", rev = "cf89a940096d7bfdf64899d99cbb4010acb38d2c", default-features = false, features = ["png", "tiff"] }
 walkdir = "2.5.0"
+

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 cargo-fuzz = true
 
 [dependencies]
-image = { version = "0.25.8", default-features = false }
+image = { git = "https://github.com/image-rs/image", rev = "cf89a940096d7bfdf64899d99cbb4010acb38d2c", default-features = false }
 
 [dependencies.image-extras]
 path = ".."

--- a/fuzz/fuzzers/fuzzer_script_icns.rs
+++ b/fuzz/fuzzers/fuzzer_script_icns.rs
@@ -14,7 +14,10 @@ fuzz_target!(|data: &[u8]| {
     };
     let mut limits = image::Limits::default();
     limits.max_alloc = Some(32 * 1024 * 1024); // 32 MiB
-    if limits.reserve(decoder.total_bytes()).is_err() {
+    let Ok(info) = decoder.prepare_image() else {
+        return;
+    };
+    if limits.reserve(info.layout.total_bytes()).is_err() {
         return;
     }
     if decoder.set_limits(limits).is_err() {

--- a/fuzz/fuzzers/fuzzer_script_ora.rs
+++ b/fuzz/fuzzers/fuzzer_script_ora.rs
@@ -14,7 +14,10 @@ fuzz_target!(|data: &[u8]| {
     };
     let mut limits = image::Limits::default();
     limits.max_alloc = Some(1024 * 1024); // 1 MiB
-    if limits.reserve(decoder.total_bytes()).is_err() {
+    let Ok(info) = decoder.prepare_image() else {
+        return;
+    };
+    if limits.reserve(info.layout.total_bytes()).is_err() {
         return;
     }
     if decoder.set_limits(limits).is_err() {

--- a/fuzz/fuzzers/fuzzer_script_pcx.rs
+++ b/fuzz/fuzzers/fuzzer_script_pcx.rs
@@ -12,7 +12,10 @@ fuzz_target!(|data: &[u8]| {
     };
     let mut limits = image::Limits::default();
     limits.max_alloc = Some(1024 * 1024); // 1 MiB
-    if limits.reserve(decoder.total_bytes()).is_err() {
+    let Ok(info) = decoder.prepare_image() else {
+        return;
+    };
+    if limits.reserve(info.layout.total_bytes()).is_err() {
         return;
     }
     if decoder.set_limits(limits).is_err() {

--- a/fuzz/fuzzers/fuzzer_script_sgi.rs
+++ b/fuzz/fuzzers/fuzzer_script_sgi.rs
@@ -12,7 +12,10 @@ fuzz_target!(|data: &[u8]| {
     };
     let mut limits = image::Limits::default();
     limits.max_alloc = Some(1024 * 1024); // 1 MiB
-    if limits.reserve(decoder.total_bytes()).is_err() {
+    let Ok(info) = decoder.prepare_image() else {
+        return;
+    };
+    if limits.reserve(info.layout.total_bytes()).is_err() {
         return;
     }
     if decoder.set_limits(limits).is_err() {

--- a/fuzz/fuzzers/fuzzer_script_xbm.rs
+++ b/fuzz/fuzzers/fuzzer_script_xbm.rs
@@ -12,7 +12,10 @@ fuzz_target!(|data: &[u8]| {
     };
     let mut limits = image::Limits::default();
     limits.max_alloc = Some(1024 * 1024); // 1 MiB
-    if limits.reserve(decoder.total_bytes()).is_err() {
+    let Ok(info) = decoder.prepare_image() else {
+        return;
+    };
+    if limits.reserve(info.layout.total_bytes()).is_err() {
         return;
     }
     if decoder.set_limits(limits).is_err() {

--- a/fuzz/fuzzers/fuzzer_script_xpm.rs
+++ b/fuzz/fuzzers/fuzzer_script_xpm.rs
@@ -12,7 +12,10 @@ fuzz_target!(|data: &[u8]| {
     };
     let mut limits = image::Limits::default();
     limits.max_alloc = Some(1024 * 1024); // 1 MiB
-    if limits.reserve(decoder.total_bytes()).is_err() {
+    let Ok(info) = decoder.prepare_image() else {
+        return;
+    };
+    if limits.reserve(info.layout.total_bytes()).is_err() {
         return;
     }
     if decoder.set_limits(limits).is_err() {

--- a/src/dds.rs
+++ b/src/dds.rs
@@ -12,15 +12,24 @@ use std::io::{Read, Seek};
 
 use dds::header::ParseOptions;
 use dds::{
-    Channels, ColorFormat, DataLayout, Decoder, Format, ImageViewMut, Offset, Size,
-    TextureArrayKind,
+    Channels, ColorFormat, DataLayout, Decoder, Format, ImageViewMut, Size, TextureArrayKind,
 };
 
 use image::error::{
     DecodingError, ImageError, ImageFormatHint, ImageResult, LimitError, LimitErrorKind,
-    UnsupportedError, UnsupportedErrorKind,
+    ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind,
 };
-use image::{ColorType, ExtendedColorType, ImageDecoder, ImageDecoderRect};
+use image::io::{
+    DecodedImageAttributes, DecodedMetadataHint, DecoderPreparedImage, FormatAttributes,
+    SequenceControl,
+};
+use image::{ColorType, ExtendedColorType, ImageDecoder, Limits};
+
+enum DdsDecodeState<R> {
+    Init(R),
+    Header(Decoder<R>),
+    Done,
+}
 
 /// DDS decoder.
 ///
@@ -30,70 +39,18 @@ use image::{ColorType, ExtendedColorType, ImageDecoder, ImageDecoderRect};
 /// It's possible to set the color type the image is decoded as using
 /// [`DdsDecoder::set_color_type`].
 pub struct DdsDecoder<R> {
-    inner: Decoder<R>,
-    is_cubemap: bool,
-    size: Size,
-    color: SupportedColor,
+    state: DdsDecodeState<R>,
+    requested_color: Option<SupportedColor>,
+    limits: Limits,
 }
 
 impl<R: Read> DdsDecoder<R> {
     /// Create a new decoder that decodes from the stream `r`
     pub fn new(r: R) -> ImageResult<Self> {
-        let options = ParseOptions::new_permissive(None);
-        let decoder = Decoder::new_with_options(r, &options).map_err(to_image_error)?;
-        let layout = decoder.layout();
-
-        // We only support DDS files with:
-        // - A single main image with any number of mipmaps
-        // - A texture array of length 1 representing a cube map
-        match &layout {
-            DataLayout::Volume(_) => {
-                return Err(ImageError::Decoding(DecodingError::new(
-                    format_hint(),
-                    "DDS volume textures are not supported for decoding",
-                )))
-            }
-            DataLayout::TextureArray(texture_array) => {
-                let supported_length = match texture_array.kind() {
-                    TextureArrayKind::Textures => 1,
-                    TextureArrayKind::CubeMaps => 6,
-                    TextureArrayKind::PartialCubeMap(cube_map_faces) => cube_map_faces.count(),
-                };
-                if texture_array.len() != supported_length as usize {
-                    return Err(ImageError::Decoding(DecodingError::new(
-                        format_hint(),
-                        "DDS texture arrays are not supported for decoding",
-                    )));
-                }
-            }
-            DataLayout::Texture(_) => {}
-        }
-
-        let mut size = decoder.main_size();
-        let mut color = decoder.native_color();
-        let is_cubemap = layout.is_cube_map();
-
-        // all cube map faces are read as one RGBA image
-        if is_cubemap {
-            if let (Some(width), Some(height)) =
-                (size.width.checked_mul(4), size.height.checked_mul(3))
-            {
-                size.width = width;
-                size.height = height;
-                color.channels = Channels::Rgba;
-            } else {
-                return Err(ImageError::Decoding(DecodingError::new(
-                    format_hint(),
-                    "DDS cube map faces are too large to decode",
-                )));
-            }
-        }
-
         Ok(DdsDecoder {
-            inner: decoder,
-            is_cubemap,
-            size,
-            color: SupportedColor::from_dds_widen(color),
+            state: DdsDecodeState::Init(r),
+            requested_color: None,
+            limits: Limits::default(),
         })
     }
 
@@ -124,109 +81,174 @@ impl<R: Read> DdsDecoder<R> {
                 ),
             ));
         };
-        self.color = supported_color;
+        self.requested_color = Some(supported_color);
         Ok(())
+    }
+
+    /// Like ImageDecoder::prepare_image, but returns some additional information
+    fn prepare_image_helper(&mut self) -> ImageResult<(Size, SupportedColor)> {
+        if matches!(self.state, DdsDecodeState::Init(_)) {
+            let mut state = DdsDecodeState::Done;
+            std::mem::swap(&mut state, &mut self.state);
+            let DdsDecodeState::Init(reader) = state else {
+                unreachable!();
+            };
+
+            let options = ParseOptions::new_permissive(None);
+            let mut decoder =
+                Decoder::new_with_options(reader, &options).map_err(to_image_error)?;
+            if let Some(max_alloc) = self.limits.max_alloc {
+                decoder.options.memory_limit = max_alloc.try_into().unwrap_or(usize::MAX);
+            }
+            let layout = decoder.layout();
+
+            // We only support DDS files with:
+            // - A single main image with any number of mipmaps
+            // - A texture array of length 1 representing a cube map
+            match &layout {
+                DataLayout::Volume(_) => {
+                    return Err(ImageError::Decoding(DecodingError::new(
+                        format_hint(),
+                        "DDS volume textures are not supported for decoding",
+                    )))
+                }
+                DataLayout::TextureArray(texture_array) => {
+                    let supported_length = match texture_array.kind() {
+                        TextureArrayKind::Textures => 1,
+                        TextureArrayKind::CubeMaps => 6,
+                        TextureArrayKind::PartialCubeMap(cube_map_faces) => cube_map_faces.count(),
+                    };
+                    if texture_array.len() != supported_length as usize {
+                        return Err(ImageError::Decoding(DecodingError::new(
+                            format_hint(),
+                            "DDS texture arrays are not supported for decoding",
+                        )));
+                    }
+                }
+                DataLayout::Texture(_) => {}
+            }
+
+            self.state = DdsDecodeState::Header(decoder);
+        }
+
+        let decoder = match &self.state {
+            DdsDecodeState::Init(_) => unreachable!(),
+            DdsDecodeState::Header(inner) => inner,
+            DdsDecodeState::Done => {
+                return Err(ImageError::Parameter(ParameterError::from_kind(
+                    ParameterErrorKind::NoMoreData,
+                )));
+            }
+        };
+
+        let mut size = decoder.main_size();
+        let mut color = decoder.native_color();
+        let is_cubemap = decoder.layout().is_cube_map();
+
+        // all cube map faces are read as one RGBA image
+        if is_cubemap {
+            if let (Some(width), Some(height)) =
+                (size.width.checked_mul(4), size.height.checked_mul(3))
+            {
+                size.width = width;
+                size.height = height;
+                color.channels = Channels::Rgba;
+            } else {
+                return Err(ImageError::Decoding(DecodingError::new(
+                    format_hint(),
+                    "DDS cube map faces are too large to decode",
+                )));
+            }
+        }
+
+        let output_color = if let Some(req_color) = self.requested_color {
+            req_color
+        } else {
+            SupportedColor::from_dds_widen(color)
+        };
+        Ok((size, output_color))
     }
 }
 
 impl<R: Read + Seek> ImageDecoder for DdsDecoder<R> {
-    fn dimensions(&self) -> (u32, u32) {
-        (self.size.width, self.size.height)
+    fn format_attributes(&self) -> FormatAttributes {
+        let mut attributes = FormatAttributes::default();
+        attributes.icc = DecodedMetadataHint::None;
+        attributes.exif = DecodedMetadataHint::None;
+        attributes.xmp = DecodedMetadataHint::None;
+        attributes
     }
 
-    fn color_type(&self) -> ColorType {
-        self.color.image
-    }
-
-    fn original_color_type(&self) -> ExtendedColorType {
-        match self.inner.format() {
-            Format::R1_UNORM => ExtendedColorType::L1,
-            Format::B4G4R4A4_UNORM | Format::A4B4G4R4_UNORM => ExtendedColorType::Rgba4,
-            Format::A8_UNORM => ExtendedColorType::A8,
-            _ => SupportedColor::from_dds_widen(self.inner.native_color())
-                .image
-                .into(),
-        }
+    fn prepare_image(&mut self) -> ImageResult<DecoderPreparedImage> {
+        let (size, color) = self.prepare_image_helper()?;
+        Ok(DecoderPreparedImage::new(
+            size.width,
+            size.height,
+            color.image,
+        ))
     }
 
     fn set_limits(&mut self, limits: image::Limits) -> ImageResult<()> {
-        limits.check_dimensions(self.size.width, self.size.height)?;
-
         if let Some(max_alloc) = limits.max_alloc {
-            self.inner.options.memory_limit = max_alloc.try_into().unwrap_or(usize::MAX);
+            if let DdsDecodeState::Header(inner) = &mut self.state {
+                inner.options.memory_limit = max_alloc.try_into().unwrap_or(usize::MAX);
+            }
         }
 
+        let info = self.prepare_image()?;
+        limits.check_dimensions(info.layout.width, info.layout.height)?;
         Ok(())
     }
 
     #[track_caller]
-    fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
-        let color = self.color.dds;
-        let size = self.size;
+    fn read_image(&mut self, buf: &mut [u8]) -> ImageResult<DecodedImageAttributes> {
+        let (size, color) = self.prepare_image_helper()?;
+
+        let mut state = DdsDecodeState::Done;
+        std::mem::swap(&mut self.state, &mut state);
+        let DdsDecodeState::Header(mut decoder) = state else {
+            unreachable!();
+        };
 
         assert_eq!(
             buf.len(),
-            color.buffer_size(size).unwrap(),
+            color.dds.buffer_size(size).unwrap(),
             "Buffer len does not match for {:?} and {:?}",
             size,
-            color
+            color.dds
         );
 
-        let image = ImageViewMut::new(buf, size, color).expect("Invalid buffer length");
+        let image = ImageViewMut::new(buf, size, color.dds).expect("Invalid buffer length");
 
-        if self.is_cubemap {
-            self.inner.read_cube_map(image).map_err(to_image_error)?;
+        if decoder.layout().is_cube_map() {
+            decoder.read_cube_map(image).map_err(to_image_error)?;
         } else {
-            self.inner.read_surface(image).map_err(to_image_error)?;
+            decoder.read_surface(image).map_err(to_image_error)?;
         }
 
-        Ok(())
+        let mut attribs = DecodedImageAttributes::default();
+        attribs.original_color_type = Some(match decoder.format() {
+            Format::R1_UNORM => ExtendedColorType::L1,
+            Format::B4G4R4A4_UNORM | Format::A4B4G4R4_UNORM => ExtendedColorType::Rgba4,
+            Format::A8_UNORM => ExtendedColorType::A8,
+            _ => SupportedColor::from_dds_widen(decoder.native_color())
+                .image
+                .into(),
+        });
+        Ok(attribs)
     }
 
-    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
-        (*self).read_image(buf)
-    }
-}
-
-impl<R: Read + Seek> ImageDecoderRect for DdsDecoder<R> {
-    fn read_rect(
-        &mut self,
-        x: u32,
-        y: u32,
-        width: u32,
-        height: u32,
-        buf: &mut [u8],
-        row_pitch: usize,
-    ) -> ImageResult<()> {
-        // reading rectangles is not supported for cube maps
-        if self.is_cubemap {
-            return Err(ImageError::Decoding(DecodingError::new(
-                format_hint(),
-                "read_rect is not supported for DDS cubemaps",
-            )));
+    fn more_images(&self) -> SequenceControl {
+        if matches!(self.state, DdsDecodeState::Done) {
+            SequenceControl::None
+        } else {
+            SequenceControl::MaybeMore
         }
-
-        let Some(view) =
-            ImageViewMut::new_with(buf, row_pitch, Size::new(width, height), self.color.dds)
-        else {
-            return Err(ImageError::Decoding(DecodingError::new(
-                format_hint(),
-                "Invalid buffer length for reading rect",
-            )));
-        };
-
-        self.inner
-            .read_surface_rect(view, Offset::new(x, y))
-            .map_err(to_image_error)?;
-        self.inner
-            .rewind_to_previous_surface()
-            .map_err(to_image_error)?;
-
-        Ok(())
     }
 }
 
 /// A color type supported by both the `image` and `dds` crates.
+#[derive(Clone, Copy)]
 struct SupportedColor {
     image: ColorType,
     dds: ColorFormat,

--- a/src/icns.rs
+++ b/src/icns.rs
@@ -24,8 +24,12 @@ use std::fmt::{self, Display};
 use std::io::{Cursor, Read, Seek, SeekFrom};
 
 use image::error::{
-    DecodingError, ImageFormatHint, LimitError, LimitErrorKind, UnsupportedError,
-    UnsupportedErrorKind,
+    DecodingError, ImageFormatHint, LimitError, LimitErrorKind, ParameterError, ParameterErrorKind,
+    UnsupportedError, UnsupportedErrorKind,
+};
+use image::io::{
+    DecodedImageAttributes, DecodedMetadataHint, DecoderPreparedImage, FormatAttributes,
+    SequenceControl,
 };
 use image::{ColorType, ImageDecoder, ImageError, ImageReader, ImageResult, LimitSupport, Limits};
 
@@ -200,13 +204,12 @@ pub fn decode_jpeg2000_using_hook(
     // The magic bytes have already been checked by IcnsDecoder, so it is unlikely
     // that a different format's decoder will be used be accident.
     // TODO:  explicitly set JPEG 2000 as the format, to be certain
-    let mut reader = ImageReader::new(Cursor::new(data));
-    reader = reader.with_guessed_format()?;
+    let mut reader = ImageReader::new(Cursor::new(data)).map_err(jp2_to_image_error)?;
     let mut limits = Limits::no_limits();
     limits.max_alloc = Some(allocation_limit);
-    reader.limits(limits);
+    reader.set_limits(limits).map_err(jp2_to_image_error)?;
 
-    let image = reader.decode().map_err(jp2_to_image_error)?;
+    let (image, _metadata) = reader.decode().map_err(jp2_to_image_error)?;
     if image.width() != size || image.height() != size {
         return Err(DecoderError::BadJp2Size(image.width(), image.height(), size).into());
     }
@@ -266,14 +269,20 @@ impl IcnsEntry {
     }
 }
 
+enum IcnsDecodeState {
+    Init,
+    Header {
+        main: IcnsEntry,
+        // If a mask entry applies to the main image, its details will be indicated here
+        mask: Option<IcnsEntry>,
+    },
+    Done,
+}
+
 /// ICNS decoder
 pub struct IcnsDecoder<R> {
     reader: R,
-
-    main: IcnsEntry,
-    // If a mask entry applies to the main image, its details will be indicated here
-    mask: Option<IcnsEntry>,
-
+    state: IcnsDecodeState,
     limits: Limits,
     jp2: SubformatDecodeFn,
 }
@@ -314,9 +323,18 @@ where
     /// function that can be used to decode the JP2 images. See for example
     /// [unsupported_jpeg2000], and [decode_jpeg2000_using_hook].
     pub fn new_with_decode_func(
-        mut reader: R,
+        reader: R,
         jp2: SubformatDecodeFn,
     ) -> Result<IcnsDecoder<R>, ImageError> {
+        Ok(IcnsDecoder {
+            reader,
+            state: IcnsDecodeState::Init,
+            limits: Limits::no_limits(),
+            jp2,
+        })
+    }
+
+    fn scan_file(reader: &mut R) -> ImageResult<IcnsDecodeState> {
         let mut header = [0u8; 8];
         reader.read_exact(&mut header)?;
         let (magic, file_len_field) = header.split_at(4);
@@ -393,39 +411,66 @@ where
                 return Err(DecoderError::MissingMask(main.code).into());
             }
         }
-        Ok(IcnsDecoder {
-            reader,
-            main,
-            mask,
-            limits: Limits::no_limits(),
-            jp2,
-        })
+
+        Ok(IcnsDecodeState::Header { main, mask })
     }
 }
 
 impl<R: Read + Seek> ImageDecoder for IcnsDecoder<R> {
-    fn dimensions(&self) -> (u32, u32) {
-        (self.main.code.pixel_width(), self.main.code.pixel_height())
+    fn format_attributes(&self) -> FormatAttributes {
+        // The decoder currently treats PNG and JP2 images purely as data sources,
+        // ignoring any color space information.
+        let mut attributes = FormatAttributes::default();
+        attributes.icc = DecodedMetadataHint::None;
+        attributes.exif = DecodedMetadataHint::None;
+        attributes.xmp = DecodedMetadataHint::None;
+        attributes
     }
 
-    fn color_type(&self) -> ColorType {
-        match self.main.code.encoding() {
-            Encoding::Mask8 => unreachable!(),
-            Encoding::Mono => ColorType::L8,
-            Encoding::MonoA => ColorType::La8,
-            _ => ColorType::Rgba8,
+    fn prepare_image(&mut self) -> ImageResult<DecoderPreparedImage> {
+        if matches!(self.state, IcnsDecodeState::Init) {
+            let mut state = IcnsDecodeState::Done;
+            std::mem::swap(&mut state, &mut self.state);
+            let IcnsDecodeState::Init = state else {
+                unreachable!();
+            };
+            self.state = Self::scan_file(&mut self.reader)?;
+            self.set_limits(self.limits.clone())?;
+        }
+
+        match &self.state {
+            IcnsDecodeState::Init => unreachable!(),
+            IcnsDecodeState::Header { main, .. } => Ok(DecoderPreparedImage::new(
+                main.code.pixel_width(),
+                main.code.pixel_height(),
+                match main.code.encoding() {
+                    Encoding::Mask8 => unreachable!(),
+                    Encoding::Mono => ColorType::L8,
+                    Encoding::MonoA => ColorType::La8,
+                    _ => ColorType::Rgba8,
+                },
+            )),
+
+            IcnsDecodeState::Done => Err(ImageError::Parameter(ParameterError::from_kind(
+                ParameterErrorKind::NoMoreData,
+            ))),
         }
     }
 
     fn set_limits(&mut self, mut limits: Limits) -> ImageResult<()> {
         limits.check_support(&LimitSupport::default())?;
-        let (width, height) = self.dimensions();
+        self.limits = limits.clone();
+
+        let IcnsDecodeState::Header { main, mask } = &self.state else {
+            return Ok(());
+        };
+        let (width, height) = (main.code.pixel_width(), main.code.pixel_height());
         limits.check_dimensions(width, height)?;
 
-        let icon_size = self.main.code.pixel_width();
+        let icon_size = main.code.pixel_width();
 
-        let main_data = self.main.length;
-        let mask_data = self.mask.map(|x| x.length).unwrap_or_default();
+        let main_data = main.length;
+        let mask_data = mask.map(|x| x.length).unwrap_or_default();
 
         // Decoding non PNG/JP2 icons using `icns` can create temporary images using
         // a maximum of about 4 + 4 bytes per pixel (up to 4 for the initial decoding
@@ -448,54 +493,61 @@ impl<R: Read + Seek> ImageDecoder for IcnsDecoder<R> {
         Ok(())
     }
 
-    fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
-        assert!(self.total_bytes() == buf.len().try_into().unwrap());
+    fn read_image(&mut self, buf: &mut [u8]) -> ImageResult<DecodedImageAttributes> {
+        let info = self.prepare_image()?;
+        assert!(info.total_bytes() == buf.len().try_into().unwrap());
 
-        let main_data = read_vec_at(&mut self.reader, self.main.stream_pos, self.main.length)?;
+        let mut state = IcnsDecodeState::Done;
+        std::mem::swap(&mut state, &mut self.state);
+        let IcnsDecodeState::Header { main, mask } = state else {
+            unreachable!();
+        };
+
+        let main_data = read_vec_at(&mut self.reader, main.stream_pos, main.length)?;
 
         const PNG_SIGNATURE: &[u8] = &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
         const JP2_SIGNATURE: &[u8] = &[
             0x00, 0x00, 0x00, 0x0C, 0x6A, 0x50, 0x20, 0x20, 0x0D, 0x0A, 0x87, 0x0A,
         ];
 
-        if self.main.code.encoding() == Encoding::JP2PNG {
+        if main.code.encoding() == Encoding::JP2PNG {
             // Handle JP2 or PNG images _directly_ in this implementation, in order
             // to implement memory limits and make it easier to keep these complicated
             // format decoders up to date.
             if main_data.starts_with(PNG_SIGNATURE) {
                 decode_png(
                     &main_data,
-                    self.main.code.pixel_width(),
+                    main.code.pixel_width(),
                     buf,
                     self.limits.max_alloc.unwrap_or(u64::MAX),
                 )?;
             } else if main_data.starts_with(JP2_SIGNATURE) {
                 (self.jp2)(
                     &main_data,
-                    self.main.code.pixel_width(),
+                    main.code.pixel_width(),
                     buf,
                     self.limits.max_alloc.unwrap_or(u64::MAX),
                 )?;
             } else {
-                return Err(DecoderError::NotPNGorJP2(self.main.code).into());
+                return Err(DecoderError::NotPNGorJP2(main.code).into());
             }
         } else {
-            let main = IconElement::new(self.main.code.ostype(), main_data);
+            let elem = IconElement::new(main.code.ostype(), main_data);
 
-            let img = if let Some(mask_entry) = &self.mask {
+            let img = if let Some(mask_entry) = &mask {
                 let mask_data =
                     read_vec_at(&mut self.reader, mask_entry.stream_pos, mask_entry.length)?;
                 let mask = IconElement::new(mask_entry.code.ostype(), mask_data);
 
-                main.decode_image_with_mask(&mask)?
+                elem.decode_image_with_mask(&mask)?
             } else {
-                assert!(self.main.code.mask_type().is_none());
-                main.decode_image()?
+                assert!(main.code.mask_type().is_none());
+                elem.decode_image()?
             };
-            assert!((img.width(), img.height()) == self.dimensions());
+            assert!((img.width(), img.height()) == info.layout.dimensions());
             assert!(img.pixel_format() != PixelFormat::Alpha);
 
-            match (img.pixel_format(), self.color_type()) {
+            match (img.pixel_format(), info.layout.color) {
                 (PixelFormat::Gray, ColorType::L8) => {
                     buf.copy_from_slice(img.data());
                 }
@@ -514,15 +566,19 @@ impl<R: Read + Seek> ImageDecoder for IcnsDecoder<R> {
                 _ => unreachable!(
                     "icns crate produced {:?}, not compatible with {:?}",
                     img.pixel_format(),
-                    self.color_type()
+                    info.layout.color
                 ),
             };
         }
 
-        Ok(())
+        Ok(DecodedImageAttributes::default())
     }
 
-    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
-        (*self).read_image(buf)
+    fn more_images(&self) -> SequenceControl {
+        if matches!(self.state, IcnsDecodeState::Done) {
+            SequenceControl::None
+        } else {
+            SequenceControl::MaybeMore
+        }
     }
 }

--- a/src/ora.rs
+++ b/src/ora.rs
@@ -11,19 +11,31 @@
 //! * <https://www.openraster.org/> - OpenRaster specification
 
 use image::codecs::png::PngDecoder;
-use image::error::{DecodingError, ImageFormatHint, UnsupportedError};
-use image::metadata::Orientation;
-use image::{ColorType, ExtendedColorType, ImageDecoder, ImageError, ImageResult, Limits};
+use image::error::{
+    DecodingError, ImageFormatHint, ParameterError, ParameterErrorKind, UnsupportedError,
+};
+use image::io::{DecodedImageAttributes, DecoderPreparedImage, FormatAttributes, SequenceControl};
+use image::{ImageDecoder, ImageError, ImageResult, Limits};
 use ouroboros::self_referencing;
-use std::io::{self, BufReader, Read, Seek};
+use std::io::{self, BufReader, Cursor, Read, Seek};
 use std::marker::PhantomData;
 use zip::read::{ZipArchive, ZipFile};
+
+enum OraDecodeState<'a, R>
+where
+    R: Read + Seek + 'a,
+{
+    Init(R),
+    Header(Box<PngDecoder<BufReader<SeekableArchiveFile<'a, R>>>>),
+    Done,
+}
 
 pub struct OpenRasterDecoder<'a, R>
 where
     R: Read + Seek + 'a,
 {
-    mergedimg_decoder: PngDecoder<BufReader<SeekableArchiveFile<'a, R>>>,
+    state: OraDecodeState<'a, R>,
+    limits: Limits,
 }
 
 fn openraster_format_hint() -> ImageFormatHint {
@@ -188,63 +200,120 @@ where
     /// process have not yet been implemented; input ZIP files with very many
     /// entries may require significant amounts of memory to read.
     pub fn with_limits(r: R, limits: Limits) -> Result<OpenRasterDecoder<'a, R>, ImageError> {
-        let mut archive = ZipArchive::new(r)
-            .map_err(|e| ImageError::Decoding(DecodingError::new(openraster_format_hint(), e)))?;
-
-        verify_archive(&mut archive)?;
-
-        let mergedimage_index = archive.index_for_name("mergedimage.png").ok_or_else(|| {
-            ImageError::Decoding(DecodingError::new(
-                openraster_format_hint(),
-                "OpenRaster image missing mergedimage.png entry",
-            ))
-        })?;
-
-        let file = SeekableArchiveFile::new(archive, mergedimage_index)?;
-        let decoder =
-            PngDecoder::with_limits(BufReader::new(file), limits).map_err(set_ora_image_type)?;
-
         Ok(OpenRasterDecoder {
-            mergedimg_decoder: decoder,
+            state: OraDecodeState::Init(r),
+            limits,
         })
     }
 }
 
 impl<'a, R: Read + Seek + 'a> ImageDecoder for OpenRasterDecoder<'a, R> {
-    fn dimensions(&self) -> (u32, u32) {
-        self.mergedimg_decoder.dimensions()
+    fn format_attributes(&self) -> FormatAttributes {
+        // The spec leaves it unclear how PNG metadata should be handled. At any
+        // rate, animated images are not permitted.
+        let mut empty: &[u8] = &[];
+        let decoder = PngDecoder::new(Cursor::new(&mut empty));
+        let mut attrib = decoder.format_attributes();
+        attrib.supports_animation = false;
+        attrib.supports_sequence = false;
+        attrib
     }
 
-    fn color_type(&self) -> ColorType {
-        self.mergedimg_decoder.color_type()
+    fn prepare_image(&mut self) -> ImageResult<DecoderPreparedImage> {
+        let decoder = match &mut self.state {
+            OraDecodeState::Init(_) => {
+                let mut state = OraDecodeState::Done;
+                std::mem::swap(&mut state, &mut self.state);
+                let OraDecodeState::Init(reader) = state else {
+                    unreachable!();
+                };
+
+                let mut archive = ZipArchive::new(reader).map_err(|e| {
+                    ImageError::Decoding(DecodingError::new(openraster_format_hint(), e))
+                })?;
+
+                verify_archive(&mut archive)?;
+
+                let mergedimage_index =
+                    archive.index_for_name("mergedimage.png").ok_or_else(|| {
+                        ImageError::Decoding(DecodingError::new(
+                            openraster_format_hint(),
+                            "OpenRaster image missing mergedimage.png entry",
+                        ))
+                    })?;
+
+                let file = SeekableArchiveFile::new(archive, mergedimage_index)?;
+                let decoder = Box::new(PngDecoder::with_limits(
+                    BufReader::new(file),
+                    self.limits.clone(),
+                ));
+
+                self.state = OraDecodeState::Header(decoder);
+                let OraDecodeState::Header(ref mut decoder) = self.state else {
+                    unreachable!();
+                };
+                decoder
+            }
+            OraDecodeState::Header(ref mut decoder) => decoder,
+
+            OraDecodeState::Done => {
+                return Err(ImageError::Parameter(ParameterError::from_kind(
+                    ParameterErrorKind::NoMoreData,
+                )));
+            }
+        };
+
+        decoder.prepare_image().map_err(set_ora_image_type)
     }
 
-    fn original_color_type(&self) -> ExtendedColorType {
-        self.mergedimg_decoder.original_color_type()
+    fn more_images(&self) -> SequenceControl {
+        if matches!(self.state, OraDecodeState::Done) {
+            SequenceControl::None
+        } else {
+            SequenceControl::MaybeMore
+        }
     }
 
     fn set_limits(&mut self, limits: Limits) -> ImageResult<()> {
         // Warning: this does not account for any ZIP reading overhead
-        self.mergedimg_decoder.set_limits(limits)
+        self.limits = limits.clone();
+        if let OraDecodeState::Header(ref mut decoder) = &mut self.state {
+            decoder.set_limits(limits.clone())?;
+        }
+        Ok(())
     }
 
     fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
-        self.mergedimg_decoder.icc_profile()
+        self.prepare_image()?;
+        let OraDecodeState::Header(ref mut decoder) = self.state else {
+            unreachable!();
+        };
+        decoder.icc_profile().map_err(set_ora_image_type)
     }
 
     fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
-        self.mergedimg_decoder.exif_metadata()
+        self.prepare_image()?;
+        let OraDecodeState::Header(ref mut decoder) = self.state else {
+            unreachable!();
+        };
+        decoder.exif_metadata().map_err(set_ora_image_type)
     }
 
-    fn orientation(&mut self) -> ImageResult<Orientation> {
-        self.mergedimg_decoder.orientation()
+    fn xmp_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        self.prepare_image()?;
+        let OraDecodeState::Header(ref mut decoder) = self.state else {
+            unreachable!();
+        };
+        decoder.xmp_metadata().map_err(set_ora_image_type)
     }
 
-    fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
-        self.mergedimg_decoder.read_image(buf)
-    }
-
-    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
-        (*self).read_image(buf)
+    fn read_image(&mut self, buf: &mut [u8]) -> ImageResult<DecodedImageAttributes> {
+        self.prepare_image()?;
+        let OraDecodeState::Header(ref mut decoder) = self.state else {
+            unreachable!();
+        };
+        let res = decoder.read_image(buf).map_err(set_ora_image_type);
+        self.state = OraDecodeState::Done;
+        res
     }
 }

--- a/src/otb.rs
+++ b/src/otb.rs
@@ -9,7 +9,14 @@
 use std::fmt::{self, Display};
 use std::io::{BufRead, Seek, Write};
 
-use image::error::{DecodingError, EncodingError, ImageFormatHint, LimitError, LimitErrorKind};
+use image::error::{
+    DecodingError, EncodingError, ImageFormatHint, LimitError, LimitErrorKind, ParameterError,
+    ParameterErrorKind,
+};
+use image::io::{
+    DecodedImageAttributes, DecodedMetadataHint, DecoderPreparedImage, FormatAttributes,
+    SequenceControl,
+};
 use image::{ColorType, ExtendedColorType, ImageDecoder, ImageEncoder, ImageError, ImageResult};
 
 /// All errors that can occur when attempting to encode an image to OTB format
@@ -144,10 +151,16 @@ impl From<DecoderError> for ImageError {
     }
 }
 
+enum OtbDecodeState {
+    Init,
+    Header { dimensions: (u32, u32) },
+    Done,
+}
+
 /// Decoder for Otb images.
 pub struct OtbDecoder<R> {
     reader: R,
-    dimensions: (u32, u32),
+    state: OtbDecodeState,
 }
 
 impl<R> OtbDecoder<R>
@@ -156,19 +169,13 @@ where
 {
     /// Create a new `OtbDecoder`.
     pub fn new(reader: R) -> Result<OtbDecoder<R>, ImageError> {
-        let mut decoder = Self::new_decoder(reader);
-        decoder.read_metadata()?;
-        Ok(decoder)
-    }
-
-    fn new_decoder(reader: R) -> OtbDecoder<R> {
-        Self {
+        Ok(Self {
             reader,
-            dimensions: (0, 0),
-        }
+            state: OtbDecodeState::Init,
+        })
     }
 
-    fn read_metadata(&mut self) -> Result<(), ImageError> {
+    fn read_metadata(&mut self) -> Result<(u32, u32), ImageError> {
         let mut buf = [0_u8; 1];
 
         self.reader.read_exact(&mut buf)?;
@@ -210,32 +217,62 @@ where
             return Err(DecoderError::UnsupportedColorDepth(depth).into());
         }
 
-        self.dimensions = (width as u32, height as u32);
-
-        Ok(())
+        Ok((width as u32, height as u32))
     }
 }
 
 impl<R: BufRead + Seek> ImageDecoder for OtbDecoder<R> {
-    fn dimensions(&self) -> (u32, u32) {
-        self.dimensions
+    fn format_attributes(&self) -> FormatAttributes {
+        let mut attributes = FormatAttributes::default();
+        attributes.icc = DecodedMetadataHint::None;
+        attributes.exif = DecodedMetadataHint::None;
+        attributes.xmp = DecodedMetadataHint::None;
+        attributes
     }
 
-    fn color_type(&self) -> ColorType {
-        ColorType::L8
+    fn prepare_image(&mut self) -> ImageResult<DecoderPreparedImage> {
+        let dimensions = match self.state {
+            OtbDecodeState::Init => {
+                let dimensions = self.read_metadata()?;
+                self.state = OtbDecodeState::Header { dimensions };
+                dimensions
+            }
+            OtbDecodeState::Header { dimensions } => dimensions,
+
+            OtbDecodeState::Done => {
+                return Err(ImageError::Parameter(ParameterError::from_kind(
+                    ParameterErrorKind::NoMoreData,
+                )));
+            }
+        };
+
+        Ok(DecoderPreparedImage::new(
+            dimensions.0,
+            dimensions.1,
+            ColorType::L8,
+        ))
     }
 
-    fn original_color_type(&self) -> ExtendedColorType {
-        ExtendedColorType::L1
+    fn more_images(&self) -> SequenceControl {
+        if matches!(self.state, OtbDecodeState::Done) {
+            SequenceControl::None
+        } else {
+            SequenceControl::MaybeMore
+        }
     }
 
-    fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
-        let (width, height) = (self.dimensions.0 as usize, self.dimensions.1 as usize);
+    fn read_image(&mut self, buf: &mut [u8]) -> ImageResult<DecodedImageAttributes> {
+        let info = self.prepare_image()?;
+        let (width, height) = info.layout.dimensions();
 
-        assert_eq!(buf.len(), width * height, "Invalid buffer length");
+        assert_eq!(
+            buf.len() as u64,
+            u64::from(width) * u64::from(height),
+            "Invalid buffer length"
+        );
 
         // Read entire image data into a buffer
-        let mut byte_buf = vec![0_u8; (width * height).div_ceil(8)].into_boxed_slice();
+        let mut byte_buf = vec![0_u8; ((width * height) as usize).div_ceil(8)].into_boxed_slice();
         self.reader.read_exact(&mut byte_buf)?;
 
         // Set a byte in buf for every bit in the image data
@@ -253,11 +290,11 @@ impl<R: BufRead + Seek> ImageDecoder for OtbDecoder<R> {
                 };
             }
         }
-        Ok(())
-    }
+        let mut attrib = DecodedImageAttributes::default();
+        attrib.original_color_type = Some(ExtendedColorType::L1);
 
-    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
-        (*self).read_image(buf)
+        self.state = OtbDecodeState::Done;
+        Ok(attrib)
     }
 }
 
@@ -290,8 +327,8 @@ mod test {
             0x0E, 0x4E, 0x67, 0x0F, 0xFF, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
             0x00, // End Image Data
         ];
-        let decoder = crate::otb::OtbDecoder::new(Cursor::new(otb_data)).unwrap();
-        let (width, height) = decoder.dimensions();
+        let mut decoder = crate::otb::OtbDecoder::new(Cursor::new(otb_data)).unwrap();
+        let (width, height) = decoder.prepare_image().unwrap().layout.dimensions();
         assert!(width == 0x48);
         assert!(height == 0x1C);
         let mut img_bytes = vec![0; 2016];
@@ -334,8 +371,8 @@ mod test {
             0b00_000000,
             0b0000_0000,
         ];
-        let decoder = crate::otb::OtbDecoder::new(Cursor::new(image_data)).unwrap();
-        let (width, height) = decoder.dimensions();
+        let mut decoder = crate::otb::OtbDecoder::new(Cursor::new(image_data)).unwrap();
+        let (width, height) = decoder.prepare_image().unwrap().layout.dimensions();
         assert!(width == 10);
         assert!(height == 10);
         let mut img_bytes = vec![0; 100];
@@ -370,8 +407,8 @@ mod test {
             0b00100100, // row7
             0b00011000, // row8
         ];
-        let decoder = crate::otb::OtbDecoder::new(Cursor::new(image_data)).unwrap();
-        let (width, height) = decoder.dimensions();
+        let mut decoder = crate::otb::OtbDecoder::new(Cursor::new(image_data)).unwrap();
+        let (width, height) = decoder.prepare_image().unwrap().layout.dimensions();
         assert!(width == 8);
         assert!(height == 8);
         let mut img_bytes = vec![0; 64];

--- a/src/pcx.rs
+++ b/src/pcx.rs
@@ -8,15 +8,28 @@
 use std::io::{self, BufRead, Read, Seek};
 use std::iter;
 
+use image::error::{ParameterError, ParameterErrorKind};
+use image::io::{
+    DecodedImageAttributes, DecodedMetadataHint, DecoderPreparedImage, FormatAttributes,
+    SequenceControl,
+};
 use image::{ColorType, ExtendedColorType, ImageDecoder, ImageError, ImageResult};
+
+enum PcxDecodeState<R>
+where
+    R: Read,
+{
+    Init(R),
+    Header(pcx::Reader<R>),
+    Done,
+}
 
 /// Decoder for PCX images.
 pub struct PCXDecoder<R>
 where
     R: Read,
 {
-    dimensions: (u32, u32),
-    inner: pcx::Reader<R>,
+    state: PcxDecodeState<R>,
 }
 
 impl<R> PCXDecoder<R>
@@ -25,10 +38,9 @@ where
 {
     /// Create a new `PCXDecoder`.
     pub fn new(r: R) -> Result<PCXDecoder<R>, ImageError> {
-        let inner = pcx::Reader::new(r).map_err(convert_pcx_decode_error)?;
-        let dimensions = (u32::from(inner.width()), u32::from(inner.height()));
-
-        Ok(PCXDecoder { dimensions, inner })
+        Ok(PCXDecoder {
+            state: PcxDecodeState::Init(r),
+        })
     }
 }
 
@@ -37,51 +49,82 @@ fn convert_pcx_decode_error(err: io::Error) -> ImageError {
 }
 
 impl<R: BufRead + Seek> ImageDecoder for PCXDecoder<R> {
-    fn dimensions(&self) -> (u32, u32) {
-        self.dimensions
+    fn format_attributes(&self) -> FormatAttributes {
+        let mut attributes = FormatAttributes::default();
+        attributes.icc = DecodedMetadataHint::None;
+        attributes.exif = DecodedMetadataHint::None;
+        attributes.xmp = DecodedMetadataHint::None;
+        attributes
     }
 
-    fn color_type(&self) -> ColorType {
-        ColorType::Rgb8
+    fn prepare_image(&mut self) -> ImageResult<DecoderPreparedImage> {
+        let dimensions = match &self.state {
+            PcxDecodeState::Init(_) => {
+                let mut state = PcxDecodeState::Done;
+                std::mem::swap(&mut state, &mut self.state);
+                let PcxDecodeState::Init(reader) = state else {
+                    unreachable!();
+                };
+                let inner = pcx::Reader::new(reader).map_err(convert_pcx_decode_error)?;
+                let dimensions = inner.dimensions();
+                self.state = PcxDecodeState::Header(inner);
+                dimensions
+            }
+            PcxDecodeState::Header(inner) => inner.dimensions(),
+
+            PcxDecodeState::Done => {
+                return Err(ImageError::Parameter(ParameterError::from_kind(
+                    ParameterErrorKind::NoMoreData,
+                )));
+            }
+        };
+
+        Ok(DecoderPreparedImage::new(
+            u32::from(dimensions.0),
+            u32::from(dimensions.1),
+            ColorType::Rgb8,
+        ))
     }
 
-    fn original_color_type(&self) -> ExtendedColorType {
-        if self.inner.is_paletted() {
-            return ExtendedColorType::Unknown(self.inner.header.bit_depth);
-        }
+    fn read_image(&mut self, buf: &mut [u8]) -> ImageResult<DecodedImageAttributes> {
+        let info = self.prepare_image()?;
+        assert_eq!(u64::try_from(buf.len()), Ok(info.total_bytes()));
 
-        match (
-            self.inner.header.number_of_color_planes,
-            self.inner.header.bit_depth,
-        ) {
-            (1, 1) => ExtendedColorType::L1,
-            (1, 2) => ExtendedColorType::L2,
-            (1, 4) => ExtendedColorType::L4,
-            (1, 8) => ExtendedColorType::L8,
-            (3, 1) => ExtendedColorType::Rgb1,
-            (3, 2) => ExtendedColorType::Rgb2,
-            (3, 4) => ExtendedColorType::Rgb4,
-            (3, 8) => ExtendedColorType::Rgb8,
-            (4, 1) => ExtendedColorType::Rgba1,
-            (4, 2) => ExtendedColorType::Rgba2,
-            (4, 4) => ExtendedColorType::Rgba4,
-            (4, 8) => ExtendedColorType::Rgba8,
-            (_, _) => unreachable!(),
-        }
-    }
+        let mut state = PcxDecodeState::Done;
+        std::mem::swap(&mut state, &mut self.state);
+        let PcxDecodeState::Header(mut inner) = state else {
+            unreachable!();
+        };
 
-    fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
-        assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
+        let orig_color_type = if inner.is_paletted() {
+            ExtendedColorType::Unknown(inner.header.bit_depth)
+        } else {
+            match (inner.header.number_of_color_planes, inner.header.bit_depth) {
+                (1, 1) => ExtendedColorType::L1,
+                (1, 2) => ExtendedColorType::L2,
+                (1, 4) => ExtendedColorType::L4,
+                (1, 8) => ExtendedColorType::L8,
+                (3, 1) => ExtendedColorType::Rgb1,
+                (3, 2) => ExtendedColorType::Rgb2,
+                (3, 4) => ExtendedColorType::Rgb4,
+                (3, 8) => ExtendedColorType::Rgb8,
+                (4, 1) => ExtendedColorType::Rgba1,
+                (4, 2) => ExtendedColorType::Rgba2,
+                (4, 4) => ExtendedColorType::Rgba4,
+                (4, 8) => ExtendedColorType::Rgba8,
+                (_, _) => unreachable!(),
+            }
+        };
 
-        let height = self.inner.height() as usize;
-        let width = self.inner.width() as usize;
+        let height = inner.height() as usize;
+        let width = inner.width() as usize;
 
-        match self.inner.palette_length() {
+        match inner.palette_length() {
             // No palette to interpret, so we can just write directly to buf
             None => {
                 for i in 0..height {
                     let offset = i * 3 * width;
-                    self.inner
+                    inner
                         .next_row_rgb(&mut buf[offset..offset + (width * 3)])
                         .map_err(convert_pcx_decode_error)?;
                 }
@@ -96,14 +139,14 @@ impl<R: BufRead + Seek> ImageDecoder for PCXDecoder<R> {
 
                 for i in 0..height {
                     let offset = i * width;
-                    self.inner
+                    inner
                         .next_row_paletted(&mut pal_buf[offset..offset + width])
                         .map_err(convert_pcx_decode_error)?;
                 }
 
                 let mut palette: Vec<u8> =
                     std::iter::repeat_n(0, 3 * palette_length as usize).collect();
-                self.inner
+                inner
                     .read_palette(&mut palette[..])
                     .map_err(convert_pcx_decode_error)?;
 
@@ -120,10 +163,16 @@ impl<R: BufRead + Seek> ImageDecoder for PCXDecoder<R> {
             }
         }
 
-        Ok(())
+        let mut attribs = DecodedImageAttributes::default();
+        attribs.original_color_type = Some(orig_color_type);
+        Ok(attribs)
     }
 
-    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
-        (*self).read_image(buf)
+    fn more_images(&self) -> SequenceControl {
+        if matches!(self.state, PcxDecodeState::Done) {
+            SequenceControl::None
+        } else {
+            SequenceControl::MaybeMore
+        }
     }
 }

--- a/src/sgi.rs
+++ b/src/sgi.rs
@@ -29,8 +29,13 @@ use std::io::BufRead;
 
 use image::error::{
     DecodingError, ImageError, ImageFormatHint, ImageResult, LimitError, LimitErrorKind,
+    ParameterError, ParameterErrorKind,
 };
-use image::{ColorType, ExtendedColorType, ImageDecoder, LimitSupport, Limits};
+use image::io::{
+    DecodedImageAttributes, DecodedMetadataHint, DecoderPreparedImage, FormatAttributes,
+    SequenceControl,
+};
+use image::{ColorType, ImageDecoder, LimitSupport, Limits};
 
 /// The length of the SGI .rgb file header, including padding
 const HEADER_FULL_LENGTH: usize = 512;
@@ -196,10 +201,17 @@ fn parse_header(
     ))
 }
 
+enum SgiDecodeState {
+    Init,
+    Header(SgiRgbHeaderInfo),
+    Done,
+}
+
 /// Decoder for SGI (.rgb) images.
 pub struct SgiDecoder<R> {
-    info: SgiRgbHeaderInfo,
+    state: SgiDecodeState,
     reader: R,
+    limits: Limits,
 }
 
 impl<R> SgiDecoder<R>
@@ -207,14 +219,11 @@ where
     R: BufRead,
 {
     /// Create a new `SgiDecoder`. Assumes `r` starts at seek position 0.
-    pub fn new(mut r: R) -> Result<SgiDecoder<R>, ImageError> {
-        let mut header = [0u8; HEADER_FULL_LENGTH];
-        r.read_exact(&mut header)?;
-        let (header_info, _name) = parse_header(&header)?;
-
+    pub fn new(r: R) -> Result<SgiDecoder<R>, ImageError> {
         Ok(SgiDecoder {
-            info: header_info,
+            state: SgiDecodeState::Init,
             reader: r,
+            limits: Limits::default(),
         })
     }
 }
@@ -515,24 +524,56 @@ fn process_data_segment<const DEEP: bool>(
 }
 
 impl<R: BufRead> ImageDecoder for SgiDecoder<R> {
-    fn dimensions(&self) -> (u32, u32) {
-        (self.info.xsize as u32, self.info.ysize as u32)
+    fn format_attributes(&self) -> FormatAttributes {
+        let mut attributes = FormatAttributes::default();
+        attributes.icc = DecodedMetadataHint::None;
+        attributes.exif = DecodedMetadataHint::None;
+        attributes.xmp = DecodedMetadataHint::None;
+        attributes
     }
 
-    fn color_type(&self) -> ColorType {
-        self.info.color_type
+    fn prepare_image(&mut self) -> ImageResult<DecoderPreparedImage> {
+        if matches!(self.state, SgiDecodeState::Init) {
+            let mut state = SgiDecodeState::Done;
+            std::mem::swap(&mut state, &mut self.state);
+            let SgiDecodeState::Init = state else {
+                unreachable!();
+            };
+
+            let mut header = [0u8; HEADER_FULL_LENGTH];
+            self.reader.read_exact(&mut header)?;
+            let (info, _name) = parse_header(&header)?;
+            self.state = SgiDecodeState::Header(info);
+            self.set_limits(self.limits.clone())?;
+        }
+
+        match &self.state {
+            SgiDecodeState::Init => unreachable!(),
+            SgiDecodeState::Header(info) => Ok(DecoderPreparedImage::new(
+                u32::from(info.xsize),
+                u32::from(info.ysize),
+                info.color_type,
+            )),
+
+            SgiDecodeState::Done => Err(ImageError::Parameter(ParameterError::from_kind(
+                ParameterErrorKind::NoMoreData,
+            ))),
+        }
     }
 
-    fn original_color_type(&self) -> ExtendedColorType {
-        self.info.color_type.into()
-    }
+    fn read_image(&mut self, buf: &mut [u8]) -> ImageResult<DecodedImageAttributes> {
+        let layout = self.prepare_image()?.layout;
+        assert_eq!(u64::try_from(buf.len()), Ok(layout.total_bytes()));
 
-    fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
-        assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
+        let mut state = SgiDecodeState::Done;
+        std::mem::swap(&mut state, &mut self.state);
+        let SgiDecodeState::Header(info) = state else {
+            unreachable!();
+        };
 
-        let channels = self.info.color_type.channel_count();
-        let deep = self.info.color_type.bytes_per_pixel() > channels;
-        if self.info.is_rle {
+        let channels = info.color_type.channel_count();
+        let deep = info.color_type.bytes_per_pixel() > channels;
+        if info.is_rle {
             /* Tricky case: need to read the RLE offset tables to determine
              * where to find the scanlines for each plane. Images can place
              * the scanlines whereever, and processing them in logical order
@@ -549,7 +590,7 @@ impl<R: BufRead> ImageDecoder for SgiDecoder<R> {
              */
 
             /* `rle_offset_entries` has maximum value `4 * (2^16-1)` and will not overflow */
-            let rle_offset_entries = (channels as u32) * (self.info.ysize as u32);
+            let rle_offset_entries = (channels as u32) * (info.ysize as u32);
 
             let mut rle_table: Vec<SgiRgbScanlineState> = Vec::new();
             /* Tiny invalid images can trigger medium-size 4 * (2^16-1) allocations here;
@@ -574,8 +615,8 @@ impl<R: BufRead> ImageDecoder for SgiDecoder<R> {
             );
             // Read offset table
             for plane in 0..channels {
-                for y in 0..self.info.ysize {
-                    let idx = (plane as usize) * (self.info.ysize as usize) + (y as usize);
+                for y in 0..info.ysize {
+                    let idx = (plane as usize) * (info.ysize as usize) + (y as usize);
                     let mut tmp = [0u8; 4];
                     self.reader.read_exact(&mut tmp)?;
                     rle_table[idx].offset = u32::from_be_bytes(tmp);
@@ -585,8 +626,8 @@ impl<R: BufRead> ImageDecoder for SgiDecoder<R> {
             }
             // Read length table, and validate (offset, length) pairs
             for plane in 0..channels {
-                for y in 0..self.info.ysize {
-                    let idx = (plane as usize) * (self.info.ysize as usize) + (y as usize);
+                for y in 0..info.ysize {
+                    let idx = (plane as usize) * (info.ysize as usize) + (y as usize);
                     let mut tmp = [0u8; 4];
                     self.reader.read_exact(&mut tmp)?;
                     rle_table[idx].length = u32::from_be_bytes(tmp);
@@ -629,18 +670,12 @@ impl<R: BufRead> ImageDecoder for SgiDecoder<R> {
                 }
 
                 let (new_state, done) = if deep {
-                    process_data_segment::<true>(buf, self.info, rle_state, &mut rle_table, buffer)?
+                    process_data_segment::<true>(buf, info, rle_state, &mut rle_table, buffer)?
                 } else {
-                    process_data_segment::<false>(
-                        buf,
-                        self.info,
-                        rle_state,
-                        &mut rle_table,
-                        buffer,
-                    )?
+                    process_data_segment::<false>(buf, info, rle_state, &mut rle_table, buffer)?
                 };
                 if done {
-                    return Ok(());
+                    break;
                 }
                 rle_state = new_state;
 
@@ -652,7 +687,7 @@ impl<R: BufRead> ImageDecoder for SgiDecoder<R> {
             if deep {
                 let bpp = 2 * channels;
                 // `width` will be at most `(2^16-1) * 8`, so there is never overflow
-                let width = (bpp as u32) * (self.info.xsize as u32);
+                let width = (bpp as u32) * (info.xsize as u32);
                 for plane in 0..channels as usize {
                     for row in buf.chunks_exact_mut(width as usize).rev() {
                         for px in row.chunks_exact_mut(bpp as usize) {
@@ -664,7 +699,7 @@ impl<R: BufRead> ImageDecoder for SgiDecoder<R> {
                     }
                 }
             } else {
-                let width = (channels as u32) * (self.info.xsize as u32);
+                let width = (channels as u32) * (info.xsize as u32);
                 for plane in 0..channels as usize {
                     for row in buf.chunks_exact_mut(width as usize).rev() {
                         for px in row.chunks_exact_mut(channels as usize) {
@@ -673,33 +708,43 @@ impl<R: BufRead> ImageDecoder for SgiDecoder<R> {
                     }
                 }
             }
-            Ok(())
         }
-    }
 
-    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
-        (*self).read_image(buf)
+        Ok(DecodedImageAttributes::default())
     }
 
     fn set_limits(&mut self, limits: Limits) -> ImageResult<()> {
         limits.check_support(&LimitSupport::default())?;
-        let (width, height) = self.dimensions();
-        limits.check_dimensions(width, height)?;
+        self.limits = limits;
+        let SgiDecodeState::Header(info) = self.state else {
+            return Ok(());
+        };
+
+        let (width, height) = (u32::from(info.xsize), u32::from(info.ysize));
+        self.limits.check_dimensions(width, height)?;
 
         // This will not overflow, because 8 * (2^16-1) * (2^16-1) ≤ 2^35
-        let max_image_bytes = 8 * (self.info.xsize as u64) * (self.info.ysize as u64);
+        let max_image_bytes = 8 * u64::from(info.xsize) * u64::from(info.ysize);
         // This will not overflow, because even 1 KB * (2^16-1) ≤ 2^35 ⪡ 2^64-1
         let max_table_bytes =
-            (self.info.ysize as u64) * (std::mem::size_of::<SgiRgbScanlineState>() as u64);
+            u64::from(info.ysize) * (std::mem::size_of::<SgiRgbScanlineState>() as u64);
         // This will not overflow, because it is ≤ 2^36 ⪡ 2^64-1
         let max_bytes = max_image_bytes + max_table_bytes;
 
-        let max_alloc = limits.max_alloc.unwrap_or(u64::MAX);
+        let max_alloc = self.limits.max_alloc.unwrap_or(u64::MAX);
         if max_alloc < max_bytes {
             return Err(ImageError::Limits(LimitError::from_kind(
                 LimitErrorKind::InsufficientMemory,
             )));
         }
         Ok(())
+    }
+
+    fn more_images(&self) -> SequenceControl {
+        if matches!(self.state, SgiDecodeState::Done) {
+            SequenceControl::None
+        } else {
+            SequenceControl::MaybeMore
+        }
     }
 }

--- a/src/wbmp.rs
+++ b/src/wbmp.rs
@@ -9,7 +9,12 @@
 use std::io::{BufRead, Seek, Write};
 
 use image::error::{
-    DecodingError, EncodingError, ImageFormatHint, UnsupportedError, UnsupportedErrorKind,
+    DecodingError, EncodingError, ImageFormatHint, ParameterError, ParameterErrorKind,
+    UnsupportedError, UnsupportedErrorKind,
+};
+use image::io::{
+    DecodedImageAttributes, DecodedMetadataHint, DecoderPreparedImage, FormatAttributes,
+    SequenceControl,
 };
 use image::{ColorType, ExtendedColorType, ImageDecoder, ImageEncoder, ImageError, ImageResult};
 
@@ -59,10 +64,15 @@ impl<W: Write> ImageEncoder for WbmpEncoder<W> {
     }
 }
 
+enum WbmpDecodeState<R> {
+    Init(R),
+    Header(wbmp::Decoder<R>),
+    Done,
+}
+
 /// Decoder for Wbmp images.
 pub struct WbmpDecoder<R> {
-    dimensions: (u32, u32),
-    inner: wbmp::Decoder<R>,
+    state: WbmpDecodeState<R>,
 }
 
 impl<R> WbmpDecoder<R>
@@ -71,35 +81,72 @@ where
 {
     /// Create a new `WbmpDecoder`.
     pub fn new(r: R) -> Result<WbmpDecoder<R>, ImageError> {
-        let inner = wbmp::Decoder::new(r).map_err(convert_wbmp_error)?;
-        let dimensions = inner.dimensions();
-
-        Ok(WbmpDecoder { dimensions, inner })
+        Ok(WbmpDecoder {
+            state: WbmpDecodeState::Init(r),
+        })
     }
 }
 
 impl<R: BufRead + Seek> ImageDecoder for WbmpDecoder<R> {
-    fn dimensions(&self) -> (u32, u32) {
-        self.dimensions
+    fn format_attributes(&self) -> FormatAttributes {
+        let mut attributes = FormatAttributes::default();
+        attributes.icc = DecodedMetadataHint::None;
+        attributes.exif = DecodedMetadataHint::None;
+        attributes.xmp = DecodedMetadataHint::None;
+        attributes
     }
 
-    fn color_type(&self) -> ColorType {
-        ColorType::L8
+    fn prepare_image(&mut self) -> ImageResult<DecoderPreparedImage> {
+        let dimensions = match &self.state {
+            WbmpDecodeState::Init(_) => {
+                let mut state = WbmpDecodeState::Done;
+                std::mem::swap(&mut state, &mut self.state);
+                let WbmpDecodeState::Init(reader) = state else {
+                    unreachable!();
+                };
+
+                let inner = wbmp::Decoder::new(reader).map_err(convert_wbmp_error)?;
+                let dimensions = inner.dimensions();
+                self.state = WbmpDecodeState::Header(inner);
+                dimensions
+            }
+            WbmpDecodeState::Header(decoder) => decoder.dimensions(),
+
+            WbmpDecodeState::Done => {
+                return Err(ImageError::Parameter(ParameterError::from_kind(
+                    ParameterErrorKind::NoMoreData,
+                )));
+            }
+        };
+
+        Ok(DecoderPreparedImage::new(
+            dimensions.0,
+            dimensions.1,
+            ColorType::L8,
+        ))
     }
 
-    fn original_color_type(&self) -> ExtendedColorType {
-        ExtendedColorType::L1
+    fn read_image(&mut self, buf: &mut [u8]) -> ImageResult<DecodedImageAttributes> {
+        let info = self.prepare_image()?;
+        assert_eq!(buf.len() as u64, info.total_bytes(), "Invalid buffer size");
+
+        let WbmpDecodeState::Header(decoder) = &mut self.state else {
+            unreachable!();
+        };
+        decoder.read_image_data(buf).map_err(convert_wbmp_error)?;
+        self.state = WbmpDecodeState::Done;
+
+        let mut attribs = DecodedImageAttributes::default();
+        attribs.original_color_type = Some(ExtendedColorType::L1);
+        Ok(attribs)
     }
 
-    fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
-        let (width, height) = self.dimensions;
-        assert_eq!(buf.len(), (width * height) as usize, "Invalid buffer size");
-
-        self.inner.read_image_data(buf).map_err(convert_wbmp_error)
-    }
-
-    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
-        (*self).read_image(buf)
+    fn more_images(&self) -> SequenceControl {
+        if matches!(self.state, WbmpDecodeState::Done) {
+            SequenceControl::None
+        } else {
+            SequenceControl::MaybeMore
+        }
     }
 }
 

--- a/src/xbm.rs
+++ b/src/xbm.rs
@@ -13,6 +13,10 @@ use std::fmt;
 use std::io::{BufRead, Bytes};
 
 use image::error::{DecodingError, ImageFormatHint, ParameterError, ParameterErrorKind};
+use image::io::{
+    DecodedImageAttributes, DecodedMetadataHint, DecoderPreparedImage, FormatAttributes,
+    SequenceControl,
+};
 use image::{ColorType, ExtendedColorType, ImageDecoder, ImageError, ImageResult};
 
 /// Location of a byte in the input stream.
@@ -125,9 +129,15 @@ where
     }
 }
 
+enum XbmDecodeState<R> {
+    Init(R),
+    Header(XbmStreamDecoder<IoAdapter<R>>),
+    Done,
+}
+
 /// XBM decoder (usable wrapper of XbmStreamDecoder that handles IO errors)
 pub struct XbmDecoder<R> {
-    base: XbmStreamDecoder<IoAdapter<R>>,
+    state: XbmDecodeState<R>,
 }
 
 /// Part of the XBM file in which a parse error occurs
@@ -580,42 +590,81 @@ where
 {
     /// Create a new `XBMDecoder`.
     pub fn new(reader: R) -> Result<XbmDecoder<R>, ImageError> {
-        match XbmStreamDecoder::new(IoAdapter {
-            reader: reader.bytes(),
-            error: None,
-        }) {
-            Err((mut r, e)) => Err(e).apply_after(&mut r.error),
-            Ok(x) => Ok(XbmDecoder { base: x }),
-        }
+        Ok(XbmDecoder {
+            state: XbmDecodeState::Init(reader),
+        })
     }
 
     /// Returns the (x,y) hotspot coordinates of the image, if the image provides them.
-    pub fn hotspot(&self) -> Option<(i32, i32)> {
-        self.base.header.hotspot
+    /// This will error if called after `read_image()`.
+    pub fn hotspot(&mut self) -> ImageResult<Option<(i32, i32)>> {
+        self.prepare_image()?;
+        let XbmDecodeState::Header(inner) = &self.state else {
+            unreachable!();
+        };
+        Ok(inner.header.hotspot)
     }
 }
 
 impl<R: BufRead> ImageDecoder for XbmDecoder<R> {
-    fn dimensions(&self) -> (u32, u32) {
-        (self.base.header.width, self.base.header.height)
+    fn format_attributes(&self) -> FormatAttributes {
+        let mut attributes = FormatAttributes::default();
+        attributes.icc = DecodedMetadataHint::None;
+        attributes.exif = DecodedMetadataHint::None;
+        attributes.xmp = DecodedMetadataHint::None;
+        attributes
     }
-    fn color_type(&self) -> ColorType {
-        ColorType::L8
+
+    fn prepare_image(&mut self) -> ImageResult<DecoderPreparedImage> {
+        if matches!(self.state, XbmDecodeState::Init(_)) {
+            let mut state = XbmDecodeState::Done;
+            std::mem::swap(&mut state, &mut self.state);
+            let XbmDecodeState::Init(reader) = state else {
+                unreachable!();
+            };
+
+            let decoder = match XbmStreamDecoder::new(IoAdapter {
+                reader: reader.bytes(),
+                error: None,
+            }) {
+                Err((mut r, e)) => {
+                    return Err(e).apply_after(&mut r.error);
+                }
+                Ok(x) => x,
+            };
+            self.state = XbmDecodeState::Header(decoder);
+        }
+
+        match &self.state {
+            XbmDecodeState::Init(_) => unreachable!(),
+            XbmDecodeState::Header(decoder) => Ok(DecoderPreparedImage::new(
+                decoder.header.width,
+                decoder.header.height,
+                ColorType::L8,
+            )),
+
+            XbmDecodeState::Done => Err(ImageError::Parameter(ParameterError::from_kind(
+                ParameterErrorKind::NoMoreData,
+            ))),
+        }
     }
-    fn original_color_type(&self) -> ExtendedColorType {
-        ExtendedColorType::L1
-    }
-    fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()>
-    where
-        Self: Sized,
-    {
-        for row in buf.chunks_exact_mut(self.base.header.width as usize) {
+
+    fn read_image(&mut self, buf: &mut [u8]) -> ImageResult<DecodedImageAttributes> {
+        let layout = self.prepare_image()?.layout;
+        assert_eq!(u64::try_from(buf.len()), Ok(layout.total_bytes()));
+
+        let mut state = XbmDecodeState::Done;
+        std::mem::swap(&mut state, &mut self.state);
+        let XbmDecodeState::Header(mut decoder) = state else {
+            unreachable!();
+        };
+
+        for row in buf.chunks_exact_mut(decoder.header.width as usize) {
             // The XBM format discards the last `8 * ceil(self.width / 8) - self.width` bits in each row
             for chunk in row.chunks_mut(8) {
-                let nxt = self
-                    .base
+                let nxt = decoder
                     .next_byte()
-                    .apply_after(&mut self.base.r.inner.error)?;
+                    .apply_after(&mut decoder.r.inner.error)?;
                 let val = nxt.ok_or_else(|| {
                     ImageError::Parameter(ParameterError::from_kind(
                         ParameterErrorKind::DimensionMismatch,
@@ -628,20 +677,26 @@ impl<R: BufRead> ImageDecoder for XbmDecoder<R> {
             }
         }
 
-        let val = self
-            .base
+        let val = decoder
             .next_byte()
-            .apply_after(&mut self.base.r.inner.error)?;
+            .apply_after(&mut decoder.r.inner.error)?;
         if val.is_some() {
             return Err(ImageError::Parameter(ParameterError::from_kind(
                 ParameterErrorKind::DimensionMismatch,
             )));
         }
 
-        Ok(())
+        let mut attrib = DecodedImageAttributes::default();
+        attrib.original_color_type = Some(ExtendedColorType::L1);
+        Ok(attrib)
     }
-    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
-        (*self).read_image(buf)
+
+    fn more_images(&self) -> SequenceControl {
+        if matches!(self.state, XbmDecodeState::Done) {
+            SequenceControl::None
+        } else {
+            SequenceControl::MaybeMore
+        }
     }
 }
 
@@ -653,23 +708,23 @@ mod tests {
 
     #[test]
     fn image_without_hotspot() {
-        let decoder = XbmDecoder::new(BufReader::new(
+        let mut decoder = XbmDecoder::new(BufReader::new(
             File::open("tests/images/xbm/1x1.xbm").unwrap(),
         ))
         .expect("Unable to read XBM file");
 
-        assert_eq!((1, 1), decoder.dimensions());
-        assert_eq!(None, decoder.hotspot());
+        assert_eq!((1, 1), decoder.prepare_image().unwrap().layout.dimensions());
+        assert_eq!(None, decoder.hotspot().unwrap());
     }
 
     #[test]
     fn image_with_hotspot() {
-        let decoder = XbmDecoder::new(BufReader::new(
+        let mut decoder = XbmDecoder::new(BufReader::new(
             File::open("tests/images/xbm/hotspot.xbm").unwrap(),
         ))
         .expect("Unable to read XBM file");
 
-        assert_eq!((5, 5), decoder.dimensions());
-        assert_eq!(Some((-1, 2)), decoder.hotspot());
+        assert_eq!(Some((-1, 2)), decoder.hotspot().unwrap());
+        assert_eq!((5, 5), decoder.prepare_image().unwrap().layout.dimensions());
     }
 }

--- a/src/xpm/mod.rs
+++ b/src/xpm/mod.rs
@@ -55,6 +55,11 @@ use std::io::{BufRead, Bytes};
 
 use image::error::{
     DecodingError, ImageError, ImageFormatHint, ImageResult, LimitError, LimitErrorKind,
+    ParameterError, ParameterErrorKind,
+};
+use image::io::{
+    DecodedImageAttributes, DecodedMetadataHint, DecoderPreparedImage, FormatAttributes,
+    SequenceControl,
 };
 use image::{ColorType, ImageDecoder, LimitSupport, Limits};
 
@@ -153,10 +158,19 @@ where
     }
 }
 
+enum XpmDecodeState<R> {
+    Init(R),
+    Header {
+        r: TextReader<IoAdapter<R>>,
+        info: XpmHeaderInfo,
+    },
+    Done,
+}
+
 /// XPM decoder
 pub struct XpmDecoder<R> {
-    r: TextReader<IoAdapter<R>>,
-    info: XpmHeaderInfo,
+    state: XpmDecodeState<R>,
+    limits: Limits,
 }
 
 /// Key XPM file properties determined from first line
@@ -1027,19 +1041,20 @@ where
 {
     /// Create a new [XpmDecoder].
     pub fn new(reader: R) -> Result<XpmDecoder<R>, ImageError> {
-        let mut r = TextReader::new(IoAdapter {
-            reader: reader.bytes(),
-            error: None,
-        });
-
-        let info = read_xpm_header(&mut r).apply_after(&mut r.inner.error)?;
-
-        Ok(XpmDecoder { r, info })
+        Ok(XpmDecoder {
+            state: XpmDecodeState::Init(reader),
+            limits: Limits::default(),
+        })
     }
 
     /// Returns the (x,y) hotspot coordinates of the image, if the image provides them.
-    pub fn hotspot(&self) -> Option<(i32, i32)> {
-        self.info.hotspot
+    /// This will error if called after `read_image()`.
+    pub fn hotspot(&mut self) -> ImageResult<Option<(i32, i32)>> {
+        self.prepare_image()?;
+        let XpmDecodeState::Header { info, .. } = &self.state else {
+            unreachable!();
+        };
+        Ok(info.hotspot)
     }
 }
 
@@ -1057,52 +1072,100 @@ fn handle_key_color(key: &XpmVisual, color: &[u8]) -> Result<Option<[u16; 4]>, X
 }
 
 impl<R: BufRead> ImageDecoder for XpmDecoder<R> {
-    fn dimensions(&self) -> (u32, u32) {
-        (self.info.width, self.info.height)
+    fn format_attributes(&self) -> FormatAttributes {
+        let mut attributes = FormatAttributes::default();
+        attributes.icc = DecodedMetadataHint::None;
+        attributes.exif = DecodedMetadataHint::None;
+        attributes.xmp = DecodedMetadataHint::None;
+        attributes
     }
-    fn color_type(&self) -> ColorType {
-        // note: some images specify 16-bpc colors, and fully transparent pixels are possible,
-        // so RGBA16 is needed to handle all possible cases
-        ColorType::Rgba16
-    }
-    fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()>
-    where
-        Self: Sized,
-    {
-        assert!(1 <= self.info.cpp && self.info.cpp <= 8);
 
-        let palette =
-            read_xpm_palette(&mut self.r, &self.info).apply_after(&mut self.r.inner.error)?;
+    fn prepare_image(&mut self) -> ImageResult<DecoderPreparedImage> {
+        if matches!(self.state, XpmDecodeState::Init(_)) {
+            let mut state = XpmDecodeState::Done;
+            std::mem::swap(&mut state, &mut self.state);
+            let XpmDecodeState::Init(reader) = state else {
+                unreachable!();
+            };
+
+            let mut r = TextReader::new(IoAdapter {
+                reader: reader.bytes(),
+                error: None,
+            });
+
+            let info = read_xpm_header(&mut r).apply_after(&mut r.inner.error)?;
+
+            self.state = XpmDecodeState::Header { r, info };
+            self.set_limits(self.limits.clone())?;
+        }
+
+        match &self.state {
+            XpmDecodeState::Init(_) => unreachable!(),
+            XpmDecodeState::Header { info, .. } => Ok(DecoderPreparedImage::new(
+                info.width,
+                info.height,
+                // note: some images specify 16-bpc colors, and fully transparent pixels are possible,
+                // so RGBA16 is needed to handle all possible cases
+                ColorType::Rgba16,
+            )),
+
+            XpmDecodeState::Done => Err(ImageError::Parameter(ParameterError::from_kind(
+                ParameterErrorKind::NoMoreData,
+            ))),
+        }
+    }
+
+    fn read_image(&mut self, buf: &mut [u8]) -> ImageResult<DecodedImageAttributes> {
+        let layout = self.prepare_image()?.layout;
+        assert_eq!(u64::try_from(buf.len()), Ok(layout.total_bytes()));
+
+        let mut state = XpmDecodeState::Done;
+        std::mem::swap(&mut state, &mut self.state);
+        let XpmDecodeState::Header { mut r, info } = state else {
+            unreachable!();
+        };
+        assert!(1 <= info.cpp && info.cpp <= 8);
+
+        let palette = read_xpm_palette(&mut r, &info).apply_after(&mut r.inner.error)?;
 
         // Read main image contents
-        let stride = (self.info.width as usize).checked_mul(8).unwrap();
+        let stride = (info.width as usize).checked_mul(8).unwrap();
         for (i, row) in buf.chunks_exact_mut(stride).enumerate() {
             for chunk in row.chunks_exact_mut(8) {
-                read_xpm_pixel(&mut self.r, &self.info, &palette, chunk.try_into().unwrap())
-                    .apply_after(&mut self.r.inner.error)?;
+                read_xpm_pixel(&mut r, &info, &palette, chunk.try_into().unwrap())
+                    .apply_after(&mut r.inner.error)?;
             }
 
-            if i >= (self.info.height - 1) as usize {
+            if i >= (info.height - 1) as usize {
                 // Last row,
             } else {
-                read_xpm_row_transition(&mut self.r).apply_after(&mut self.r.inner.error)?;
+                read_xpm_row_transition(&mut r).apply_after(&mut r.inner.error)?;
             }
         }
 
-        read_xpm_trailing(&mut self.r).apply_after(&mut self.r.inner.error)?;
+        read_xpm_trailing(&mut r).apply_after(&mut r.inner.error)?;
 
-        Ok(())
+        Ok(DecodedImageAttributes::default())
     }
-    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
-        (*self).read_image(buf)
+
+    fn more_images(&self) -> SequenceControl {
+        if matches!(self.state, XpmDecodeState::Done) {
+            SequenceControl::None
+        } else {
+            SequenceControl::MaybeMore
+        }
     }
 
     fn set_limits(&mut self, limits: Limits) -> ImageResult<()> {
         limits.check_support(&LimitSupport::default())?;
-        let (width, height) = self.dimensions();
-        limits.check_dimensions(width, height)?;
+        self.limits = limits;
+        let XpmDecodeState::Header { info, .. } = &self.state else {
+            return Ok(());
+        };
 
-        let max_pixels = u64::from(self.info.width) * u64::from(self.info.height);
+        self.limits.check_dimensions(info.width, info.height)?;
+
+        let max_pixels = u64::from(info.width) * u64::from(info.height);
         let max_image_bytes =
             max_pixels
                 .checked_mul(8)
@@ -1110,14 +1173,13 @@ impl<R: BufRead> ImageDecoder for XpmDecoder<R> {
                     LimitErrorKind::DimensionError,
                 )))?;
 
-        let max_table_bytes = (self.info.ncolors as u64) * (size_of::<XpmColorCodeEntry>() as u64);
+        let max_table_bytes = (info.ncolors as u64) * (size_of::<XpmColorCodeEntry>() as u64);
         let max_bytes = max_image_bytes
             .checked_add(max_table_bytes)
             .ok_or(ImageError::Limits(LimitError::from_kind(
                 LimitErrorKind::InsufficientMemory,
             )))?;
-
-        let max_alloc = limits.max_alloc.unwrap_or(u64::MAX);
+        let max_alloc = self.limits.max_alloc.unwrap_or(u64::MAX);
         if max_alloc < max_bytes {
             return Err(ImageError::Limits(LimitError::from_kind(
                 LimitErrorKind::InsufficientMemory,
@@ -1138,8 +1200,8 @@ static char *test[] = {
 \"20 5 10 1\",
 };
 ";
-        let decoder = XpmDecoder::new(&data[..]).unwrap();
-        let mut image = vec![0; decoder.total_bytes() as usize];
+        let mut decoder = XpmDecoder::new(&data[..]).unwrap();
+        let mut image = vec![0; decoder.prepare_image().unwrap().layout.total_bytes() as usize];
         assert!(decoder.read_image(&mut image).is_err());
     }
 
@@ -1151,8 +1213,8 @@ static char *test[] = {
     \"  c Antique White1\",
     \" \",
 };";
-        let decoder = XpmDecoder::new(&data[..]).unwrap();
-        let mut image = vec![0; decoder.total_bytes() as usize];
+        let mut decoder = XpmDecoder::new(&data[..]).unwrap();
+        let mut image = vec![0; decoder.prepare_image().unwrap().layout.total_bytes() as usize];
         assert!(decoder.read_image(&mut image).is_err());
     }
 
@@ -1164,12 +1226,12 @@ static char *test[] = {
         \"  c none\",
         \" \",
     };";
-        let decoder = XpmDecoder::new(&data[..data.len() - 1]).unwrap();
-        let mut image = vec![0; decoder.total_bytes() as usize];
+        let mut decoder = XpmDecoder::new(&data[..data.len() - 1]).unwrap();
+        let mut image = vec![0; decoder.prepare_image().unwrap().layout.total_bytes() as usize];
         assert!(decoder.read_image(&mut image).is_err());
 
-        let decoder = XpmDecoder::new(&data[..]).unwrap();
-        let mut image = vec![0; decoder.total_bytes() as usize];
+        let mut decoder = XpmDecoder::new(&data[..]).unwrap();
+        let mut image = vec![0; decoder.prepare_image().unwrap().layout.total_bytes() as usize];
         assert!(decoder.read_image(&mut image).is_ok());
     }
 
@@ -1183,9 +1245,9 @@ static char *test[] = {
 \"..\",
 \". \",
 };";
-        let decoder = XpmDecoder::new(&data[..]).unwrap();
-        let mut image = vec![0; decoder.total_bytes() as usize];
-        assert_eq!(decoder.hotspot(), Some((-5, 2)));
+        let mut decoder = XpmDecoder::new(&data[..]).unwrap();
+        let mut image = vec![0; decoder.prepare_image().unwrap().layout.total_bytes() as usize];
+        assert_eq!(decoder.hotspot().unwrap(), Some((-5, 2)));
         assert!(decoder.read_image(&mut image).is_ok());
     }
 }

--- a/tests/reference.rs
+++ b/tests/reference.rs
@@ -1,6 +1,21 @@
 use image::ColorType;
 use walkdir::WalkDir;
 
+fn is_type_supported(t: &str) -> bool {
+    match t {
+        "dds" => cfg!(feature = "dds"),
+        "icns" => cfg!(feature = "icns"),
+        "ora" => cfg!(feature = "ora"),
+        "otb" => cfg!(feature = "otb"),
+        "pcx" => cfg!(feature = "pcx"),
+        "sgi" => cfg!(feature = "sgi"),
+        "xbm" => cfg!(feature = "xbm"),
+        "xpm" => cfg!(feature = "xpm"),
+        "wbmp" => cfg!(feature = "wbmp"),
+        _ => panic!("Unexpected image type subfolder {t:?}, update this function"),
+    }
+}
+
 /// Test decoding of all test images in `tests/images/` against reference images
 /// (either PNG or TIFF).
 ///
@@ -29,6 +44,24 @@ fn test_decoding() {
             || entry.path().extension().unwrap() == "png"
             || entry.path().extension().unwrap() == "tiff"
         {
+            continue;
+        }
+
+        let group = entry
+            .path()
+            .ancestors()
+            .nth(1)
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap();
+        if !is_type_supported(group) {
+            println!(
+                "Skipped {}: (feature for {} disabled)",
+                entry.path().display(),
+                group
+            );
             continue;
         }
 


### PR DESCRIPTION
This PR updates all the decoders in `image-extras` to use the new `ImageDecoder` interface planned for the future `image` 1.0. 

I've refactored all the decoders to better try to match the decoding model for ImageDecoder and error if calls are out of sequence (e.g. `prepare_image()` being after `read_image()`  when `more_images()` returns `SequenceControl::None`.) This is done by modeling the decoder as a state machine with three states. (Before reading the header; between header and image; after image). For most decoders this is a rather mechanical alteration, although the changes for some formats (DDS, ICNS) are slightly more complicated.

This PR also includes a minor testing improvement (to only reference test images whose features are enabled) that I found helpful while porting the decoders.

I've marked this as a draft, since `image` 1.0 is not yet out and the `ImageDecoder` interface may still change a bit.